### PR TITLE
remove space for binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 * text eol=lf
-* .png binary
-* .jpg binary
+*.png binary
+*.jpg binary


### PR DESCRIPTION
Removed space between * and binary file extensions as that was causing all files to be treated as binary files.