### PR TITLE
Add conversions from 4326->3005 and back

### DIFF
--- a/cit3.0-web/src/helpers/conversions.js
+++ b/cit3.0-web/src/helpers/conversions.js
@@ -1,0 +1,35 @@
+import proj4 from "proj4";
+import { geojsonToWKT } from "@terraformer/wkt";
+
+export const convert3005CoordsTo4326 = (coords) => {
+  const defString =
+    "+proj=aea +lat_1=50 +lat_2=58.5 +lat_0=45 +lon_0=-126 +x_0=1000000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs";
+  proj4.defs("EPSG:3005", defString);
+  const converted = proj4(proj4("EPSG:3005"), proj4("EPSG:4326"), [
+    coords[1],
+    coords[0],
+  ]);
+  return [converted[1], converted[0]];
+};
+
+export const convert4326CoordsTo3005 = (coords) => {
+  const defString =
+    "+proj=aea +lat_1=50 +lat_2=58.5 +lat_0=45 +lon_0=-126 +x_0=1000000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs";
+  proj4.defs("EPSG:3005", defString);
+  const converted = proj4(proj4("EPSG:4326"), proj4("EPSG:3005"), [
+    coords[1],
+    coords[0],
+  ]);
+  return converted;
+};
+
+export const geoJSONToString = (geom) => {
+  if (!geom.coordinates) {
+    return null;
+  }
+  const geoJSON = {
+    type: geom.type,
+    coordinates: geom.coordinates,
+  };
+  return `SRID=3005;${geojsonToWKT(geoJSON)}`;
+};

--- a/cit3.0-web/src/store/factory/OpportunityFactory.js
+++ b/cit3.0-web/src/store/factory/OpportunityFactory.js
@@ -1,17 +1,9 @@
 import _ from "lodash";
-import { geojsonToWKT } from "@terraformer/wkt";
 import { Opportunity } from "../models/opportunity";
-
-const geoJSONToString = (geom) => {
-  if (!geom.coordinates) {
-    return null;
-  }
-  const geoJSON = {
-    type: geom.type,
-    coordinates: geom.coordinates,
-  };
-  return `SRID=3005;${geojsonToWKT(geoJSON)}`;
-};
+import {
+  convert4326CoordsTo3005,
+  geoJSONToString,
+} from "../../helpers/conversions";
 
 /**
  * Factory to convert model to request object, reason there is more
@@ -34,10 +26,11 @@ export default {
         });
       }
     });
+    const coords3005 = convert4326CoordsTo3005(state.coords);
     return {
       ...request,
       opportunity_address: state.address,
-      geo_position: `SRID=3005;POINT(${state.coords[1]} ${state.coords[0]})`,
+      geo_position: `SRID=3005;POINT(${coords3005[0]} ${coords3005[1]})`,
       parcel_geometry: geoJSONToString(state.siteInfo.geometry),
       parcel_size: state.siteInfo.parcelSize.value,
       approval_status: state.approvalStatus,

--- a/cit3.0-web/src/store/models/opportunity.js
+++ b/cit3.0-web/src/store/models/opportunity.js
@@ -1,4 +1,5 @@
 import { toKebabCase } from "../../helpers/helpers";
+import { convert3005CoordsTo4326 } from "../../helpers/conversions";
 
 /**
  * Initial opportunity model
@@ -318,7 +319,10 @@ export class Opportunity {
 
   set geoPosition(value) {
     const geo = value.match(/\((.*) (.*)\)/);
-    this.state.coords = [parseFloat(geo[2]), parseFloat(geo[1])];
+    this.state.coords = convert3005CoordsTo4326([
+      parseFloat(geo[2]),
+      parseFloat(geo[1]),
+    ]);
   }
 
   set opportunityAddress(value) {
@@ -416,7 +420,7 @@ export class Opportunity {
   }
 
   set geometry(value) {
-    this.state.siteInfo.geometry.polygon = value;
+    this.state.siteInfo.geometry.coordinates = value;
   }
 
   // User Info


### PR DESCRIPTION
Currently the Points are saying they are being saved as 3005 but they are actually being saved as SRID=3005;POINT((4326:long) (4326:lat)).  Much of the data import is in this weird form as well.  However if we update the points to actually be saving in proper 3005 coordinates this will break calculations on the back end for the data that is in the database in this form(ie Regional Districts).  If at some point we do want to fix this and be saving the points as 3005, these conversions allow us to save as 3005; (long) (lat) and converts retrieved points to 4326; lat long which is what leaflet needs to display markers/geometry, via the opportunity model and factory.