### PR TITLE
Proximity fixes

### DIFF
--- a/cit3.0-web/src/components/AddMarker/AddMarker.js
+++ b/cit3.0-web/src/components/AddMarker/AddMarker.js
@@ -31,11 +31,8 @@ export default function AddLocationMarker(props) {
     } catch (error) {
       props.setNoAddressFlag(true);
     } finally {
-      const proximity = await getProximityData(props.resourceIds, [
-        e.latlng.lat,
-        e.latlng.lng,
-      ]);
-      props.setNearbyResources(proximity);
+      const proximity = await getProximityData([e.latlng.lat, e.latlng.lng]);
+      props.setNearbyResources(proximity.data);
     }
   });
 

--- a/cit3.0-web/src/components/AddMarker/AddMarker.js
+++ b/cit3.0-web/src/components/AddMarker/AddMarker.js
@@ -18,7 +18,7 @@ export default function AddLocationMarker(props) {
     props.setNoAddressFlag(false);
     /// ///////////////////
     setPositions([e.latlng]);
-    props.setCoords([e.latlng.lat, e.latlng.lng]);
+    props.setCoords([e.latlng.lat, e.latlng.lng]); // this will trigger proximity data call in MapContainer
     try {
       const addressDataFromPoint = await getAddressFromPoint([
         e.latlng.lat,
@@ -30,9 +30,6 @@ export default function AddLocationMarker(props) {
       }
     } catch (error) {
       props.setNoAddressFlag(true);
-    } finally {
-      const proximity = await getProximityData([e.latlng.lat, e.latlng.lng]);
-      props.setNearbyResources(proximity.data);
     }
   });
 

--- a/cit3.0-web/src/components/AddMarker/ResourceMarker.js
+++ b/cit3.0-web/src/components/AddMarker/ResourceMarker.js
@@ -27,5 +27,6 @@ export default function ResourceMarker({ resourceName, resources }) {
 }
 ResourceMarker.propTypes = {
   resourceName: PropTypes.string.isRequired,
-  resources: PropTypes.arrayOf(PropTypes.shape).isRequired,
+  resources: PropTypes.oneOfType([PropTypes.string, PropTypes.shape()])
+    .isRequired,
 };

--- a/cit3.0-web/src/components/LoadingScreen/LoadingScreen.css
+++ b/cit3.0-web/src/components/LoadingScreen/LoadingScreen.css
@@ -1,0 +1,10 @@
+.spinner-container {
+    height: 50vh; 
+    padding: 2em;
+    color: #494949;
+    border: 2px solid #244278;
+}
+
+.bc-spinner {
+    color: #244278;
+}

--- a/cit3.0-web/src/components/LoadingScreen/LoadingScreen.js
+++ b/cit3.0-web/src/components/LoadingScreen/LoadingScreen.js
@@ -1,0 +1,14 @@
+import { Container, Spinner, Col } from "react-bootstrap";
+import "./LoadingScreen.css";
+
+export default function LoadingScreen() {
+  return (
+    <Container className="spinner-container d-flex flex-column justify-content-center align-items-center">
+      <Col className="d-flex flex-column justify-content-center align-items-center">
+        <h1>Loading location data for your opportunity...</h1>
+        <Spinner className="my-4 bc-spinner" animation="border" role="status" />
+        <h2>Please wait as this may take several moments</h2>
+      </Col>
+    </Container>
+  );
+}

--- a/cit3.0-web/src/components/Map/Map.js
+++ b/cit3.0-web/src/components/Map/Map.js
@@ -25,7 +25,6 @@ export default function Map({
   nearbyResources,
   coords,
   setCoords,
-  resourceIds,
   setNearbyResources,
   setAddress,
   isInteractive,
@@ -87,7 +86,6 @@ export default function Map({
       <AddLocationMarker
         setCoords={setCoords}
         setAddress={setAddress}
-        resourceIds={resourceIds}
         setNearbyResources={setNearbyResources}
         changeView={changeView}
         setError={setError}
@@ -220,7 +218,6 @@ Map.defaultProps = {
   isInteractive: true,
   isSearchMode: true,
   nearbyResources: null,
-  resourceIds: {},
   setNearbyResources: () => {},
   setCoords: () => {},
   setAddress: () => {},
@@ -235,10 +232,6 @@ Map.propTypes = {
   nearbyResources: PropTypes.shape({
     resource: PropTypes.string,
     data: PropTypes.arrayOf(PropTypes.shape),
-  }),
-  resourceIds: PropTypes.shape({
-    name: PropTypes.string,
-    id: PropTypes.string,
   }),
   setNearbyResources: PropTypes.func,
   setCoords: PropTypes.func,

--- a/cit3.0-web/src/components/Map/Map.js
+++ b/cit3.0-web/src/components/Map/Map.js
@@ -25,7 +25,6 @@ export default function Map({
   nearbyResources,
   coords,
   setCoords,
-  setNearbyResources,
   setAddress,
   isInteractive,
   isSearchMode,
@@ -86,7 +85,6 @@ export default function Map({
       <AddLocationMarker
         setCoords={setCoords}
         setAddress={setAddress}
-        setNearbyResources={setNearbyResources}
         changeView={changeView}
         setError={setError}
         setNoAddressFlag={setNoAddressFlag}
@@ -218,7 +216,6 @@ Map.defaultProps = {
   isInteractive: true,
   isSearchMode: true,
   nearbyResources: null,
-  setNearbyResources: () => {},
   setCoords: () => {},
   setAddress: () => {},
   setError: () => {},
@@ -233,7 +230,6 @@ Map.propTypes = {
     resource: PropTypes.string,
     data: PropTypes.arrayOf(PropTypes.shape),
   }),
-  setNearbyResources: PropTypes.func,
   setCoords: PropTypes.func,
   setAddress: PropTypes.func,
   setError: PropTypes.func,

--- a/cit3.0-web/src/components/MapContainer/MapContainer.js
+++ b/cit3.0-web/src/components/MapContainer/MapContainer.js
@@ -18,14 +18,18 @@ export default function MapContainer({
   setAddress,
   setError,
   setNoAddressFlag,
+  setProximityInProgress,
 }) {
   const [lastCoords, setLastCoords] = useState([]);
   const dispatch = useDispatch();
 
   const { CancelToken } = axios;
-  let source;
+  let source = CancelToken.source();
 
   const run = async (sourceToken) => {
+    // proximity call is running, do not unmount component if user hits continue
+    setProximityInProgress(true);
+    console.log("running");
     const [soilData, proximityData] = await axios.all([
       getSoilAndElevationData(coords, sourceToken),
       getProximityData(coords, sourceToken),
@@ -38,6 +42,8 @@ export default function MapContainer({
     if (proximityData) {
       dispatch(setNearbyResources(proximityData));
     }
+    // Call is finished and we can safely go to next page
+    setProximityInProgress(false);
   };
   useEffect(() => {
     // kill the axios calls if coords change
@@ -50,7 +56,7 @@ export default function MapContainer({
       run(source);
     }
     return () => {
-      source.cancel("Cancelling in cleanup");
+      source.cancel("cancel in clean up");
     };
   }, [coords]);
 
@@ -87,4 +93,5 @@ MapContainer.propTypes = {
   setAddress: PropTypes.func.isRequired,
   setError: PropTypes.func.isRequired,
   setNoAddressFlag: PropTypes.func.isRequired,
+  setProximityInProgress: PropTypes.func.isRequired,
 };

--- a/cit3.0-web/src/components/MapContainer/MapContainer.js
+++ b/cit3.0-web/src/components/MapContainer/MapContainer.js
@@ -6,16 +6,6 @@ import { getProximityData } from "../../helpers/resourceCalls";
 import { getSoilAndElevationData, buildSoilString } from "../../helpers/soil";
 import { setSoil, setElevation } from "../../store/actions/opportunity";
 
-const resourceIds = {
-  Hospitals: "5ff82cf4-0448-4063-804a-7321f0f2b4c6",
-  Schools: "5832eff2-3380-435e-911b-5ada41c1d30b",
-  "Post Secondary Schools": "8e4e2a87-2d1d-4931-828e-6327b49f310e",
-  Courts: "23aa0b75-2715-4ccb-9a36-9a608450dc2d",
-  "Walk-In Clinics": "3ca6b086-c92b-4654-ae82-ff5723d00611",
-  "Natural Resource Projects": "2b69cc4b-4076-4272-a5a0-1c731455e063",
-  "Economic Projects": "b12cd4cc-b58b-4079-b630-a20b6df58e8d",
-};
-
 export default function MapContainer({
   nearbyResources,
   setNearbyResources,
@@ -36,6 +26,7 @@ export default function MapContainer({
       dispatch(setElevation(soilData.AVG_ELEV));
     }
     const proximity = await getProximityData(coords);
+    console.log("got proximity data in MapContainer, setting nearby resources");
     dispatch(setNearbyResources(proximity.data));
   };
   useEffect(() => {
@@ -52,7 +43,6 @@ export default function MapContainer({
         style={{ height: "500px", width: "600px" }}
       >
         <Map
-          resourceIds={resourceIds}
           setNearbyResources={setNearbyResources}
           coords={coords}
           setCoords={setCoords}

--- a/cit3.0-web/src/components/MapContainer/MapContainer.js
+++ b/cit3.0-web/src/components/MapContainer/MapContainer.js
@@ -29,7 +29,6 @@ export default function MapContainer({
   const run = async (sourceToken) => {
     // proximity call is running, do not unmount component if user hits continue
     setProximityInProgress(true);
-    console.log("running");
     const [soilData, proximityData] = await axios.all([
       getSoilAndElevationData(coords, sourceToken),
       getProximityData(coords, sourceToken),

--- a/cit3.0-web/src/components/MapContainer/MapContainer.js
+++ b/cit3.0-web/src/components/MapContainer/MapContainer.js
@@ -4,11 +4,14 @@ import { useDispatch } from "react-redux";
 import Map from "../Map/Map";
 import { getProximityData } from "../../helpers/resourceCalls";
 import { getSoilAndElevationData, buildSoilString } from "../../helpers/soil";
-import { setSoil, setElevation } from "../../store/actions/opportunity";
+import {
+  setSoil,
+  setElevation,
+  setNearbyResources,
+} from "../../store/actions/opportunity";
 
 export default function MapContainer({
   nearbyResources,
-  setNearbyResources,
   coords,
   setCoords,
   setAddress,
@@ -26,7 +29,6 @@ export default function MapContainer({
       dispatch(setElevation(soilData.AVG_ELEV));
     }
     const proximity = await getProximityData(coords);
-    console.log("got proximity data in MapContainer, setting nearby resources");
     dispatch(setNearbyResources(proximity.data));
   };
   useEffect(() => {
@@ -43,7 +45,6 @@ export default function MapContainer({
         style={{ height: "500px", width: "600px" }}
       >
         <Map
-          setNearbyResources={setNearbyResources}
           coords={coords}
           setCoords={setCoords}
           setAddress={setAddress}
@@ -67,7 +68,7 @@ MapContainer.propTypes = {
   }).isRequired,
   coords: PropTypes.arrayOf(PropTypes.number).isRequired,
   setCoords: PropTypes.func.isRequired,
-  setNearbyResources: PropTypes.func.isRequired,
+  // setNearbyResources: PropTypes.func.isRequired,
   setAddress: PropTypes.func.isRequired,
   setError: PropTypes.func.isRequired,
   setNoAddressFlag: PropTypes.func.isRequired,

--- a/cit3.0-web/src/components/OpportunityView/OpportunityView.js
+++ b/cit3.0-web/src/components/OpportunityView/OpportunityView.js
@@ -77,7 +77,6 @@ export default function OpportunityView({ view }) {
           >
             <Map
               isSearchMode={false}
-              setNearbyResources={(r) => dispatch(setNearbyResources(r))}
               coords={coords}
               setCoords={(c) => dispatch(setCoords(c))}
               setAddress={(a) => dispatch(setAddress(a))}

--- a/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
+++ b/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
@@ -1,8 +1,7 @@
 import { useHistory } from "react-router-dom";
-import { Container, Row, Col } from "react-bootstrap";
+import { Container, Row, Col, Modal } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
 import { useEffect, useState } from "react";
-import axios from "axios";
 import NavigationHeader from "../../Headers/NavigationHeader/NavigationHeader";
 import MapContainer from "../../MapContainer/MapContainer";
 import AddressSearchBar from "../../AddressSearchBar/AddressSearchBar";
@@ -28,6 +27,7 @@ import {
 } from "../../../store/actions/opportunity";
 import Radios from "../../FormComponents/Radios";
 import Terms from "../../Terms/Terms";
+import LoadingScreen from "../../LoadingScreen/LoadingScreen";
 
 export default function AddOpportunity() {
   const dispatch = useDispatch();
@@ -56,6 +56,27 @@ export default function AddOpportunity() {
   const [error, setError] = useState(null);
   const [agreed, setAgreed] = useState(false);
   const [noAddressFlag, setNoAddressFlag] = useState(false);
+  /// //////////////////////////////////////////////////////
+  const [proximityInProgress, setProximityInProgress] = useState(false);
+  const [changePage, setChangePage] = useState(false);
+  const [show, setShow] = useState(false);
+
+  const handleClose = () => setShow(false);
+  const handleShow = () => setShow(true);
+
+  const history = useHistory();
+
+  useEffect(() => {
+    if (changePage && !proximityInProgress) {
+      handleClose();
+      history.push(`/opportunity/site-info`);
+    }
+  }, [changePage, proximityInProgress]);
+
+  const goToNextPage = () => {
+    handleShow();
+    setChangePage(true);
+  };
 
   const handleRadioChange = (name, label, value) => {
     setHasApproval(label);
@@ -66,7 +87,6 @@ export default function AddOpportunity() {
     }
   };
 
-  const history = useHistory();
   const title1 = "Add an Opportunity";
   const title2 = "Confirm Property";
   const text1 =
@@ -189,10 +209,6 @@ export default function AddOpportunity() {
     }
   }, [siteId, noAddressFlag]);
 
-  const goToNextPage = () => {
-    history.push(`/opportunity/site-info`);
-  };
-
   useEffect(() => {
     if (editing) {
       setBlockContinue(false);
@@ -202,7 +218,16 @@ export default function AddOpportunity() {
   return (
     <>
       <NavigationHeader currentStep={1} />
-
+      <Modal
+        show={show}
+        onHide={handleClose}
+        keyboard={false}
+        backdrop="static"
+        size="lg"
+        centered
+      >
+        <LoadingScreen />
+      </Modal>
       <Container>
         <Row>
           {!address ? (
@@ -304,6 +329,7 @@ export default function AddOpportunity() {
               setSiteId={(id) => dispatch(setSiteId(id))}
               setError={setError}
               setNoAddressFlag={setNoAddressFlag}
+              setProximityInProgress={setProximityInProgress}
             />
           </Col>
         </Row>

--- a/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
+++ b/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
@@ -56,11 +56,13 @@ export default function AddOpportunity() {
   const [error, setError] = useState(null);
   const [agreed, setAgreed] = useState(false);
   const [noAddressFlag, setNoAddressFlag] = useState(false);
-  /// //////////////////////////////////////////////////////
+
+  // Handle ProximityData call still running and change of page
   const [proximityInProgress, setProximityInProgress] = useState(false);
   const [changePage, setChangePage] = useState(false);
-  const [show, setShow] = useState(false);
 
+  // Handle Modal if proximity data is still loading
+  const [show, setShow] = useState(false);
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
 

--- a/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
+++ b/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
@@ -2,6 +2,7 @@ import { useHistory } from "react-router-dom";
 import { Container, Row, Col } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
 import { useEffect, useState } from "react";
+import axios from "axios";
 import NavigationHeader from "../../Headers/NavigationHeader/NavigationHeader";
 import MapContainer from "../../MapContainer/MapContainer";
 import AddressSearchBar from "../../AddressSearchBar/AddressSearchBar";
@@ -17,7 +18,6 @@ import {
 import {
   setAddress,
   setCoords,
-  setNearbyResources,
   setResourceIds,
   setPID,
   setGeometry,
@@ -65,6 +65,8 @@ export default function AddOpportunity() {
       setBlockContinue(true);
     }
   };
+
+  const cancelToken = axios.CancelToken.source();
 
   const history = useHistory();
   const title1 = "Add an Opportunity";
@@ -299,7 +301,6 @@ export default function AddOpportunity() {
               nearbyResources={nearbyResources}
               coords={coords}
               setResourceIds={(r) => dispatch(setResourceIds(r))}
-              setNearbyResources={(r) => dispatch(setNearbyResources(r))}
               setAddress={(a) => dispatch(setAddress(a))}
               setCoords={(c) => dispatch(setCoords(c))}
               setSiteId={(id) => dispatch(setSiteId(id))}

--- a/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
+++ b/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
@@ -66,8 +66,6 @@ export default function AddOpportunity() {
     }
   };
 
-  const cancelToken = axios.CancelToken.source();
-
   const history = useHistory();
   const title1 = "Add an Opportunity";
   const title2 = "Confirm Property";

--- a/cit3.0-web/src/components/Page/SiteInformation/SiteInformation.css
+++ b/cit3.0-web/src/components/Page/SiteInformation/SiteInformation.css
@@ -1,12 +1,3 @@
 .bcgov-warning-background {
     border: 1px solid rgb(252, 186, 25);
 }
-
-.spinner-container {
-    height: 50vh; 
-    color: #494949;
-}
-
-.bc-spinner {
-    color: #244278;
-}

--- a/cit3.0-web/src/components/Page/SiteInformation/SiteInformation.js
+++ b/cit3.0-web/src/components/Page/SiteInformation/SiteInformation.js
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 import { useHistory } from "react-router-dom";
-import { Spinner, Container, Col } from "react-bootstrap";
-import { useSelector } from "react-redux";
+import { Container } from "react-bootstrap";
 import { Alert } from "shared-components";
 import { MdError } from "react-icons/md";
 
@@ -17,43 +16,20 @@ export default function SiteInformation({ location }) {
     history.push(`/opportunity/property-details`);
   };
 
-  const municipality = useSelector((state) => state.opportunity.municipality);
-
-  // this page will run the searches and pass the data to opportunity view and map
   return (
     <>
       <NavigationHeader currentStep={2} />
-      {municipality.name ? (
-        <>
-          <Container className="p-0 mt-3">
-            <Alert
-              icon={<MdError size={32} />}
-              type="warning"
-              styling="bcgov-warning-background"
-              element="This shows you all the information we could collect from many open
+      <Container className="p-0 mt-3">
+        <Alert
+          icon={<MdError size={32} />}
+          type="warning"
+          styling="bcgov-warning-background"
+          element="This shows you all the information we could collect from many open
         source BC Gov. databases"
-            />
-          </Container>
-          <OpportunityView data={location.state} />
-          <ButtonRow
-            showPrevious
-            prevRoute="/opportunity"
-            onClick={goToNextPage}
-          />
-        </>
-      ) : (
-        <Container className="spinner-container d-flex flex-column justify-content-center align-items-center">
-          <Col className="d-flex flex-column justify-content-center align-items-center">
-            <h1>Loading location data for your opportunity...</h1>
-            <Spinner
-              className="my-4 bc-spinner"
-              animation="border"
-              role="status"
-            />
-            <h2>Please wait as this may take several moments</h2>
-          </Col>
-        </Container>
-      )}
+        />
+      </Container>
+      <OpportunityView data={location.state} />
+      <ButtonRow showPrevious prevRoute="/opportunity" onClick={goToNextPage} />
     </>
   );
 }

--- a/cit3.0-web/src/helpers/resourceCalls.js
+++ b/cit3.0-web/src/helpers/resourceCalls.js
@@ -100,33 +100,21 @@ function returnResourcesWithinMaxDistance(resources, maxDistance, coords) {
   return nearbyResources;
 }
 
-export const getProximityData = async (coords) => {
-  const result = await axios.get(
-    `/api/opportunity/proximity/?${querystring.encode({
-      lat: coords[0],
-      lng: coords[1],
-    })}`
-  );
-  return result;
-};
-// try {
-//   const final = Promise.all(
-//     Object.entries(resources).map(async ([resource, resourceId]) => {
-//       const resourceData = await getResourceData(resourceId);
-//       const resourcesWithinMax = returnResourcesWithinMaxDistance(
-//         resourceData,
-//         50,
-//         coords
-//       );
-//       return [
-//         resource,
-//         addDistanceToResourcesMine(resourcesWithinMax, coords),
-//       ];
-//     })
-//   );
-//   const result = await final;
-//   return Object.fromEntries(result);
-// } catch (error) {
-//   console.log("Error retrieving proximity data");
-//   return null;
-// }
+export const getProximityData = async (coords, source) =>
+  axios
+    .get(
+      `/api/opportunity/proximity/?${querystring.encode({
+        lat: coords[0],
+        lng: coords[1],
+      })}`,
+      {
+        cancelToken: source.token,
+      }
+    )
+    .then((data) => data.data)
+    .catch((thrown) => {
+      if (axios.isCancel(thrown)) {
+        console.log("proximity request cancelled", thrown.message);
+      }
+      return null;
+    });

--- a/cit3.0-web/src/helpers/soil.js
+++ b/cit3.0-web/src/helpers/soil.js
@@ -9,16 +9,23 @@ export const buildSoilString = (properties) => {
   return soil;
 };
 
-export async function getSoilAndElevationData(coords4326) {
+export async function getSoilAndElevationData(coords4326, source) {
   const converted = convertCoords(coords4326);
   const url = `https://openmaps.gov.bc.ca/geo/pub/WHSE_TERRESTRIAL_ECOLOGY.STE_SOIL_SURVEYS_MVW/wfs?service=wfs&version=2.0.0&request=GetFeature&outputFormat=application%2Fjson&TypeNames=pub:WHSE_TERRESTRIAL_ECOLOGY.STE_SOIL_SURVEYS_MVW&srsName=EPSG%3A4326&cql_filter=INTERSECTS(SHAPE,POINT(${converted[0]} ${converted[1]}))`;
   return axios
-    .get(url)
+    .get(url, {
+      cancelToken: source.token,
+    })
     .then((data) => {
       if (data.data.features.length) {
         return data.data.features[0].properties;
       }
       return null;
     })
-    .catch(() => null);
+    .catch((thrown) => {
+      if (axios.isCancel(thrown)) {
+        console.log("request cancelled in soil", thrown.message);
+      }
+      return null;
+    });
 }

--- a/cit3.0-web/src/store/reducers/opportunity.js
+++ b/cit3.0-web/src/store/reducers/opportunity.js
@@ -87,18 +87,12 @@ export default function opportunity(
       state.siteInfo.PID.value = action.payload;
       break;
     case ADD_GEOMETRY:
-      console.log("IN GEOM - payload", action.payload);
-      console.log("current geom: ", state.siteInfo.geometry.coordinates);
       if (!action.payload) {
-        console.log("in geom: should set to null");
         state.siteInfo.geometry.coordinates = null;
-        console.log(state.siteInfo.geometry.coordinates);
       } else if (!state.siteInfo.geometry.coordinates) {
-        console.log("in GEOM: else if");
         state.siteInfo.geometry.coordinates = action.payload.coordinates;
         state.siteInfo.geometry.type = action.payload.type;
       } else {
-        console.log("in geom ELSE");
         state.siteInfo.geometry.coordinates = [
           ...state.siteInfo.geometry.coordinates,
           ...action.payload.coordinates,
@@ -118,13 +112,9 @@ export default function opportunity(
 
       break;
     case ADD_PARCEL_SIZE:
-      console.log("parcelSize: ", action.payload);
       if (state.siteInfo.parcelSize.value && action.payload !== null) {
-        console.log("add parcel size if");
         state.siteInfo.parcelSize.value += action.payload;
       } else {
-        console.log("add parcel size else");
-
         state.siteInfo.parcelSize.value = action.payload;
       }
       break;


### PR DESCRIPTION
- refactor to remove multiple getProximityData calls on mapClick vs address search - now only one call is made in MapContainer, removed call from AddMarker
- proximityData call is now cancelled on multiple address search/map clicks
- remove loading from SiteInformation page and move to AddOpportunity -> on continue click if proximity call is not finished page will show a Loading Screen modal before routing to next page