### PR TITLE
Filter reset button changes + bug fixes

### DIFF
--- a/cit3.0-web/src/components/CommunityOrPopulationProximityFilter/CommunityOrPopulationProximityFilter.js
+++ b/cit3.0-web/src/components/CommunityOrPopulationProximityFilter/CommunityOrPopulationProximityFilter.js
@@ -28,8 +28,8 @@ export default function CommunityOrPopulationProximityFilter(props) {
     min: inputRange.min,
     max: inputRange.max,
   });
-  const [minInput, setMinInput] = useState(inputRange.min);
-  const [maxInput, setMaxInput] = useState(inputRange.max);
+  const [minInput, setMinInput] = useState(String(inputRange.min));
+  const [maxInput, setMaxInput] = useState(String(inputRange.max));
   const [validMax, setValidMax] = useState(true);
   const [validMin, setValidMin] = useState(true);
   const [
@@ -113,13 +113,19 @@ export default function CommunityOrPopulationProximityFilter(props) {
 
   const handleClear = () => {
     setInputRangeValue({ min: inputRangeMin, max: inputRangeMax });
-    setMaxInput(inputRangeMax);
-    setMinInput(inputRangeMin);
+    setMaxInput(String(inputRangeMax));
+    setMinInput(String(inputRangeMin));
     setValidMin(true);
     setValidMax(true);
     setCurrentCommunity(null);
     setCurrentPopulation(null);
     setIsModified(false);
+    setIsSelected(false);
+    setShow(false);
+    setDisplayRange({
+      min: inputRangeMin,
+      max: inputRangeMax,
+    });
   };
   const handleShow = () => {
     setShow(true);
@@ -129,8 +135,8 @@ export default function CommunityOrPopulationProximityFilter(props) {
   const handleClose = () => {
     setShow(false);
     setInputRangeValue({ ...displayRange });
-    setMaxInput(displayRange.max);
-    setMinInput(displayRange.min);
+    setMaxInput(String(displayRange.max));
+    setMinInput(String(displayRange.min));
     setValidMin(true);
     setValidMax(true);
     setCurrentCommunity(currentCommunityOnOpen);
@@ -215,7 +221,7 @@ export default function CommunityOrPopulationProximityFilter(props) {
         </Modal.Body>
         <Modal.Footer>
           <Button
-            label="Reset"
+            label="Remove filter"
             styling="bcgov-normal-white mr-auto modal-reset-button btn"
             onClick={handleClear}
           />
@@ -237,6 +243,11 @@ export default function CommunityOrPopulationProximityFilter(props) {
   );
 }
 
+CommunityOrPopulationProximityFilter.defaultProps = {
+  currentCommunity: null,
+  currentPopulation: null,
+};
+
 CommunityOrPopulationProximityFilter.propTypes = {
   inputRange: PropTypes.shape({
     min: PropTypes.number.isRequired,
@@ -254,8 +265,11 @@ CommunityOrPopulationProximityFilter.propTypes = {
   currentCommunity: PropTypes.shape({
     value: PropTypes.number.isRequired,
     label: PropTypes.string.isRequired,
-  }).isRequired,
+  }),
   setCurrentCommunity: PropTypes.func.isRequired,
-  currentPopulation: PropTypes.number.isRequired,
+  currentPopulation: PropTypes.shape({
+    value: PropTypes.number.isRequired,
+    label: PropTypes.string.isRequired,
+  }),
   setCurrentPopulation: PropTypes.func.isRequired,
 };

--- a/cit3.0-web/src/components/NumberRangeFilter/NumberRangeFilter.js
+++ b/cit3.0-web/src/components/NumberRangeFilter/NumberRangeFilter.js
@@ -46,6 +46,12 @@ export default function NumberRangeFilter(props) {
     setValidMin(true);
     setValidMax(true);
     setIsModified(false);
+    setIsSelected(false);
+    setShow(false);
+    setDisplayRange({
+      min: inputRangeValue.min,
+      max: inputRangeValue.max,
+    });
   };
   const handleShow = () => setShow(true);
   const handleClose = () => {
@@ -111,7 +117,7 @@ export default function NumberRangeFilter(props) {
         </Modal.Body>
         <Modal.Footer>
           <Button
-            label="Reset"
+            label="Remove filter"
             styling="bcgov-normal-white mr-auto modal-reset-button btn"
             onClick={handleClear}
           />

--- a/cit3.0-web/src/components/NumberRangeFilter/NumberRangeFilter.js
+++ b/cit3.0-web/src/components/NumberRangeFilter/NumberRangeFilter.js
@@ -22,8 +22,8 @@ export default function NumberRangeFilter(props) {
     setDisplayRange,
   } = props;
   const [show, setShow] = useState(false);
-  const [minInput, setMinInput] = useState(inputRange.min);
-  const [maxInput, setMaxInput] = useState(inputRange.max);
+  const [minInput, setMinInput] = useState(String(inputRange.min));
+  const [maxInput, setMaxInput] = useState(String(inputRange.max));
   const [validMax, setValidMax] = useState(true);
   const [validMin, setValidMin] = useState(true);
   const [isModified, setIsModified] = useState(false);
@@ -49,8 +49,8 @@ export default function NumberRangeFilter(props) {
     setIsSelected(false);
     setShow(false);
     setDisplayRange({
-      min: inputRangeValue.min,
-      max: inputRangeValue.max,
+      min: inputRangeMin,
+      max: inputRangeMax,
     });
   };
   const handleShow = () => setShow(true);
@@ -58,8 +58,8 @@ export default function NumberRangeFilter(props) {
     setShow(false);
     // Reset values to previous state
     setInputRangeValue({ ...displayRange });
-    setMaxInput(displayRange.max);
-    setMinInput(displayRange.min);
+    setMaxInput(String(displayRange.max));
+    setMinInput(String(displayRange.min));
     setValidMin(true);
     setValidMax(true);
   };

--- a/cit3.0-web/src/components/SelectFilter/SelectFilter.js
+++ b/cit3.0-web/src/components/SelectFilter/SelectFilter.js
@@ -38,8 +38,8 @@ export default function SelectFilter(props) {
     return allSelectedFilterLabels.join(", ");
   };
 
-  const createFilterString = () => {
-    const allSelectedFilters = filters.filter(
+  const createFilterString = (currentFilters) => {
+    const allSelectedFilters = currentFilters.filter(
       (filter) => filter.isSelected === true
     );
 
@@ -67,7 +67,7 @@ export default function SelectFilter(props) {
     } else {
       setIsSelected(false);
     }
-    setQueryFilters(createFilterString());
+    setQueryFilters(createFilterString(filters));
     setShow(false);
   };
   const handleClear = () => {
@@ -77,6 +77,10 @@ export default function SelectFilter(props) {
     }));
 
     setFilters(clearedFilters);
+
+    setIsSelected(false);
+    setQueryFilters(createFilterString(clearedFilters));
+    setShow(false);
   };
 
   const toggleFilter = (filterLabel) => {
@@ -145,7 +149,7 @@ export default function SelectFilter(props) {
         </Modal.Body>
         <Modal.Footer>
           <Button
-            label="Reset"
+            label="Remove filter"
             styling="bcgov-normal-white mr-auto modal-reset-button btn"
             onClick={handleClear}
           />


### PR DESCRIPTION
- Changed reset filter functionality to remove all filters and save instead. 
- Updated reset button label
- Fixed some issues where text inputs in the filters were still being set as numbers instead of strings
- Fixed some incorrect prop types in filters