### PR TITLE
fix header styling

### DIFF
--- a/cit3.0-web/src/components/Page/citHome/citHome.css
+++ b/cit3.0-web/src/components/Page/citHome/citHome.css
@@ -37,3 +37,7 @@
     height: 100%;
     border: none;
 }
+
+.main-text {
+    font-size: 40px;
+}

--- a/cit3.0-web/src/components/Page/citHome/citHome.js
+++ b/cit3.0-web/src/components/Page/citHome/citHome.js
@@ -97,7 +97,7 @@ export default function citHome() {
       <Container className="py-5 px-2">
         <Row>
           <Col sm={9}>
-            <h1 className="main-header-text py-2">
+            <h1 className="main-text py-2">
               Welcome to the Community <br />
               Information Tool
             </h1>


### PR DESCRIPTION
Fixing the alignment issue for the HomePage moved the cit-home header text to the right.  This fixes that.