### PR TITLE
IDIR Login for PBI: refactor to add idp to keycloak and only allow users logged in with I…

### DIFF
--- a/cit3.0-web/src/contexts/authStateContext.js
+++ b/cit3.0-web/src/contexts/authStateContext.js
@@ -17,20 +17,24 @@ const AuthStateContextProvider = ({ children }) => {
 
   React.useEffect(() => {
     if (keycloak.obj && keycloak.obj.authenticated) {
+      let idp = "";
       const loadUserInfo = () => {
         keycloak.obj
           .loadUserInfo()
           .then((user) => {
-            setUserInfo(user);
+            idp = user.preferred_username.slice(
+              user.preferred_username.indexOf("@") + 1
+            );
+            setUserInfo({ ...user, idp });
             getUser({ email: user.email }).then((existingUser) => {
               if (existingUser.data.length) {
-                dispatch(setUser(existingUser.data[0]));
+                dispatch(setUser({ ...existingUser.data[0], idp }));
               } else {
                 postUser(
                   UserFactory.createStateFromKeyCloak(user),
                   keycloak.obj.token
                 ).then((newUser) => {
-                  dispatch(setUser(newUser.data));
+                  dispatch(setUser({ ...newUser.data, idp }));
                 });
               }
             });

--- a/cit3.0-web/src/hooks/useKeycloakWrapper.js
+++ b/cit3.0-web/src/hooks/useKeycloakWrapper.js
@@ -38,6 +38,15 @@ export function useKeycloakWrapper() {
     userInfo && (userInfo.name || userInfo.preferred_username);
 
   /**
+   * Return the user's identity provider
+   */
+  const idp = () =>
+    userInfo &&
+    userInfo.preferred_username.slice(
+      userInfo.preferred_username.indexOf("@") + 1
+    );
+
+  /**
    * Return the user's first name
    */
   const firstName = () =>
@@ -81,6 +90,7 @@ export function useKeycloakWrapper() {
     firstName: firstName(),
     lastName: lastName(),
     email: email(),
+    idp: idp(),
     isAdmin:
       hasRole(Roles.SYSTEM_ADMINISTRATOR) || hasRole(Roles.SUPER_ADMINISTRATOR),
     isEdo: hasRole(Roles.SYSTEM_ADMINISTRATOR),

--- a/cit3.0-web/src/store/factory/UserFactory.js
+++ b/cit3.0-web/src/store/factory/UserFactory.js
@@ -8,6 +8,7 @@ function createStateFromResponse(response) {
     name: response.name,
     email: response.email,
     role: response.role,
+    idp: response.idp,
     dateCreated: response.date_created,
     municipalities: response.municipalities,
     regionalDistricts: response.regional_districts,
@@ -22,6 +23,9 @@ function createStateFromKeyCloak(keycloak) {
   return {
     name: keycloak.displayName || keycloak.name,
     email: keycloak.email,
+    idp: keycloak.preferred_username.slice(
+      keycloak.preferred_username.indexOf("@") + 1
+    ),
     role: "",
     municipalities: [],
     regionalDistricts: [],

--- a/cit3.0-web/src/store/models/user.js
+++ b/cit3.0-web/src/store/models/user.js
@@ -2,6 +2,7 @@ const USER_INITIALIZATION = () => ({
   name: "",
   email: "",
   role: "",
+  idp: "",
   municipalities: [],
   regionalDistricts: [],
 });


### PR DESCRIPTION
…DIR to view the internal pbi report, redirect to IDIR log in only from citHome (/dashboard/home)