### PR TITLE
fix typo on dashboard page (first li was missing text), new text to siteInfo warning page

### DIFF
--- a/cit3.0-web/src/components/Page/EDODashboard/EDODashboard.js
+++ b/cit3.0-web/src/components/Page/EDODashboard/EDODashboard.js
@@ -203,9 +203,6 @@ export default function EDODashboard() {
             </ul>
           </li>
         </ul>
-        {/* <p className="dashboard-text mb-4">
-          
-        </p> */}
         <div className="add-opportunity-button">{addOpportunityButton}</div>
         <hr ref={resultRef} />
         {markAsSoldStatus === "Error" ? (

--- a/cit3.0-web/src/components/Page/EDODashboard/EDODashboard.js
+++ b/cit3.0-web/src/components/Page/EDODashboard/EDODashboard.js
@@ -173,7 +173,8 @@ export default function EDODashboard() {
           <li>
             Properties must be zoned for industrial, commercial, or agricultural
             use. Industrial properties of any size may be listed. Commercial and
-            agricultural
+            agricultural properties may be listed if they are at least 5 acres
+            in size.
           </li>
           <li>Land must be available for sale or lease.</li>
           <li>

--- a/cit3.0-web/src/components/Page/EDODashboard/EDODashboard.js
+++ b/cit3.0-web/src/components/Page/EDODashboard/EDODashboard.js
@@ -194,15 +194,18 @@ export default function EDODashboard() {
                 Presence of provincially significant cultural or natural
                 heritage features
               </li>
+              <li>
+                Listings must be approved by either a municipality, regional
+                district, electoral area, province, First Nation or a regional
+                economic development organization, and from the Chief
+                Administrative Officer or their delegate.
+              </li>
             </ul>
           </li>
         </ul>
-        <p className="dashboard-text mb-4">
-          Listings must be approved by either a municipality, regional district,
-          electoral area, province, First Nation or a regional economic
-          development organization, and from the Chief Administrative Officer or
-          their delegate.
-        </p>
+        {/* <p className="dashboard-text mb-4">
+          
+        </p> */}
         <div className="add-opportunity-button">{addOpportunityButton}</div>
         <hr ref={resultRef} />
         {markAsSoldStatus === "Error" ? (

--- a/cit3.0-web/src/components/Page/SiteInformation/SiteInformation.js
+++ b/cit3.0-web/src/components/Page/SiteInformation/SiteInformation.js
@@ -23,7 +23,7 @@ export default function SiteInformation({ location }) {
         <Alert
           type="warning"
           styling="bcgov-warning-background"
-          element="Proximity (distance to) information is populated from available B.C. Open Data sources and cannot be edited. Data is presented for reference use only. All information should be verified independently before being used or relied upon. The Province of British Columbia does not guarantee the quality, accuracy, completeness or timeliness of this information."
+          element="Your listing will include the following location and proximity data available from open data sources. You will be able to add additional data to your listing in the next steps, including site servicing information. The remainder of the information is not editable and is provided for reference only. All information should be verified independently before being used or relied upon. The Province of British Columbia does not guarantee the quality, accuracy, completeness or timeliness of this information."
         />
       </Container>
       <OpportunityView data={location.state} />


### PR DESCRIPTION
CIT-367 - Dashboard page was missing the rest of the sentence for the first li.