### PR TITLE
Powerbi header

### DIFF
--- a/cit3.0-web/src/components/Headers/Header/Header.js
+++ b/cit3.0-web/src/components/Headers/Header/Header.js
@@ -1,6 +1,6 @@
 import "./Header.scss";
 
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { useHistory, useLocation } from "react-router";
 import { Button, Navbar, Nav } from "react-bootstrap";
 import { useKeycloakWrapper } from "../../../hooks/useKeycloakWrapper";
@@ -11,16 +11,23 @@ const Header = () => {
   const keycloak = useKeycloakWrapper();
   const history = useHistory();
   const location = useLocation();
+  const [isPowerBI, setIsPowerBI] = useState(false);
 
   const title = () => {
     if (location.pathname.includes("/investmentopportunities")) {
       return "Community Investment Opportunities Tool";
     }
-    if (location.pathname.includes("/dashboard")) {
+    if (location.pathname.includes("/cit-dashboard")) {
       return "Community Information Tool";
     }
     return "";
   };
+
+  useEffect(() => {
+    if (title() === "Community Information Tool") {
+      setIsPowerBI(true);
+    }
+  }, []);
 
   return (
     <>
@@ -49,7 +56,7 @@ const Header = () => {
           {keycloak.obj && <UserProfile />}
         </Navbar>
       </header>
-      {keycloak.obj.authenticated ? (
+      {keycloak.obj.authenticated && !isPowerBI ? (
         <div className="navigation-container no-print">
           {keycloak.hasRole([Roles.ECONOMIC_DEVELOPMENT_OFFICER]) && (
             <Button

--- a/cit3.0-web/src/components/Headers/Header/Header.js
+++ b/cit3.0-web/src/components/Headers/Header/Header.js
@@ -11,7 +11,7 @@ const Header = () => {
   const keycloak = useKeycloakWrapper();
   const history = useHistory();
   const location = useLocation();
-  const [isPowerBI, setIsPowerBI] = useState(false);
+  const [isPowerBI, setIsPowerBI] = useState(null);
 
   const title = () => {
     if (location.pathname.includes("/investmentopportunities")) {
@@ -26,6 +26,8 @@ const Header = () => {
   useEffect(() => {
     if (title() === "Community Information Tool") {
       setIsPowerBI(true);
+    } else {
+      setIsPowerBI(false);
     }
   }, []);
 

--- a/cit3.0-web/src/components/Headers/Header/UserProfile.js
+++ b/cit3.0-web/src/components/Headers/Header/UserProfile.js
@@ -1,9 +1,7 @@
-import React from "react";
-import { Image, NavDropdown } from "react-bootstrap";
+import React, { useState, useEffect } from "react";
 import { Button } from "shared-components";
 
 import { FaSignInAlt, FaSignOutAlt } from "react-icons/fa";
-import { NavLink } from "react-router-dom";
 import { useKeycloakWrapper } from "../../../hooks/useKeycloakWrapper";
 import useConfiguration from "../../../hooks/useConfiguration";
 
@@ -21,6 +19,15 @@ const UserProfile = () => {
     : fallbacDisplayName;
 
   const configuration = useConfiguration();
+  const [isPowerBI, setIsPowerBI] = useState(null);
+
+  useEffect(() => {
+    if (location.pathname.includes("/cit-dashboard")) {
+      setIsPowerBI(true);
+    } else {
+      setIsPowerBI(false);
+    }
+  }, []);
 
   return (
     <>
@@ -38,9 +45,15 @@ const UserProfile = () => {
               </>
             }
             onClick={() => {
-              keycloak.obj.logout({
-                redirectUri: `${configuration.baseUrl}`,
-              });
+              if (isPowerBI) {
+                keycloak.obj.logout({
+                  redirectUri: `${configuration.baseUrl}/cit-dashboard`,
+                });
+              } else {
+                keycloak.obj.logout({
+                  redirectUri: `${configuration.baseUrl}`,
+                });
+              }
             }}
             styling="btn bcgov-button bcgov-normal-white"
           />
@@ -53,9 +66,19 @@ const UserProfile = () => {
               </>
             }
             onClick={() => {
-              keycloak.obj.login({
-                redirectUri: `${configuration.baseUrl}${window.location.pathname}`,
-              });
+              if (isPowerBI) {
+                const loginWithIdir = keycloak.obj.createLoginUrl({
+                  idpHint: "idir",
+                  redirectUri: encodeURI(
+                    `${configuration.baseUrl}${window.location.pathname}`
+                  ),
+                });
+                window.location.href = loginWithIdir;
+              } else {
+                keycloak.obj.login({
+                  redirectUri: `${configuration.baseUrl}${window.location.pathname}`,
+                });
+              }
             }}
             styling="btn bcgov-button bcgov-normal-white"
           />

--- a/cit3.0-web/src/components/Page/PowerBi/PowerBi.css
+++ b/cit3.0-web/src/components/Page/PowerBi/PowerBi.css
@@ -17,3 +17,8 @@
     padding: 10px 65px;
     background: #38598a;
 }
+
+.copy-btn {
+    background-color: #fcba19;
+    color: black;
+}

--- a/cit3.0-web/src/components/Page/PowerBi/PowerBi.css
+++ b/cit3.0-web/src/components/Page/PowerBi/PowerBi.css
@@ -11,16 +11,9 @@
     position: relative;
 }
 
-/* .over {
-    position: absolute;
-    left: 0;
-    top: 0;
+.cit-header {
+    display: flex;
+    justify-content: flex-end;
+    padding: 10px 65px;
+    background: #38598a;
 }
-
-.public {
-    top: 70px;
-}
-
-.logged-in {
-    top: 129px;
-} */

--- a/cit3.0-web/src/components/Page/PowerBi/PowerBi.css
+++ b/cit3.0-web/src/components/Page/PowerBi/PowerBi.css
@@ -11,7 +11,7 @@
     position: relative;
 }
 
-.over {
+/* .over {
     position: absolute;
     left: 0;
     top: 0;
@@ -23,4 +23,4 @@
 
 .logged-in {
     top: 129px;
-}
+} */

--- a/cit3.0-web/src/components/Page/PowerBi/PowerBi.js
+++ b/cit3.0-web/src/components/Page/PowerBi/PowerBi.js
@@ -168,7 +168,7 @@ export default function PowerBi(props) {
               disabled={!selected}
               ref={tooltip}
               type="button"
-              className="bcgov-normal-blue btn primary over"
+              className="copy-btn btn primary"
               onClick={createAndCopyLinkToClipboard}
             >
               Copy Link

--- a/cit3.0-web/src/components/Page/PowerBi/PowerBi.js
+++ b/cit3.0-web/src/components/Page/PowerBi/PowerBi.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
 import "./PowerBi.css";
+import { Row, Col, Container } from "react-bootstrap";
 import { PowerBIEmbed } from "powerbi-client-react";
 import { models } from "powerbi-client";
 import { useSelector } from "react-redux";
@@ -24,10 +25,8 @@ export default function PowerBi(props) {
   const reportId = Config.pbiReportIdInternal;
 
   const { search } = useLocation();
-  const [community, setCommunity] = useState(
-    new URLSearchParams(search).get("community")
-  );
-  const [regionalDistrict, setRegionalDistrict] = useState(
+  const [community] = useState(new URLSearchParams(search).get("community"));
+  const [regionalDistrict] = useState(
     new URLSearchParams(search).get("regionalDistrict")
   );
 
@@ -41,7 +40,7 @@ export default function PowerBi(props) {
           column: "Community Name",
         },
         operator: "In",
-        values: [community],
+        values: [community.split("-").join(" ")],
       };
     } else if (regionalDistrict) {
       result = {
@@ -51,7 +50,7 @@ export default function PowerBi(props) {
           column: "Regional District",
         },
         operator: "In",
-        values: [regionalDistrict],
+        values: [regionalDistrict.split("-").join(" ")],
       };
     }
     return result;
@@ -102,13 +101,40 @@ export default function PowerBi(props) {
     window.report.print();
   };
 
+  const [commValue, setCommValue] = useState("");
+  const getCommunity = () => {
+    console.log(commValue);
+  };
+
   return embedToken ? (
     <div id="embed-container">
-      <Button
-        styling="bcgov-normal-blue btn primary over"
-        label="Save As PDF"
-        onClick={saveAsPDF}
-      />
+      <div className="navigation-container no-print">jfdskl</div>
+      <Container>
+        <Row
+          style={{ border: "1px solid red" }}
+          className="d-flex justify-content-center py-2"
+        >
+          <div className="mr-2">
+            <Button
+              styling="bcgov-normal-blue btn primary over"
+              label="Save As PDF"
+              onClick={saveAsPDF}
+            />
+          </div>
+          <div>
+            <input
+              onChange={(e) => setCommValue(e.target.value)}
+              value={commValue}
+              placeholder="Community name"
+            />
+            <Button
+              styling="bcgov-normal-blue btn primary over"
+              label="Copy link to community"
+              onClick={getCommunity}
+            />
+          </div>
+        </Row>
+      </Container>
       <PowerBIEmbed
         embedConfig={{
           type: "report",
@@ -174,6 +200,24 @@ export default function PowerBi(props) {
                 }
               },
             ],
+            [
+              "bookmarkApplied",
+              function (event) {
+                console.log("filters", event);
+                window.report.getFilters().then((filters) => {
+                  console.log(filters);
+                });
+              },
+            ],
+            [
+              "buttonClicked",
+              function (event) {
+                console.log("button", event);
+                window.report.getFilters().then((filters) => {
+                  console.log(filters);
+                });
+              },
+            ],
           ])
         }
         // // Add CSS classes to the div element
@@ -181,6 +225,7 @@ export default function PowerBi(props) {
         // set report object
         getEmbeddedComponent={(embeddedReport) => {
           window.report = embeddedReport;
+          console.log("embed", embeddedReport);
         }}
       />
     </div>

--- a/cit3.0-web/src/components/Page/PowerBi/PowerBi.js
+++ b/cit3.0-web/src/components/Page/PowerBi/PowerBi.js
@@ -6,7 +6,6 @@ import { PowerBIEmbed } from "powerbi-client-react";
 import { models } from "powerbi-client";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
-import { Button } from "shared-components";
 import { Typeahead } from "react-bootstrap-typeahead";
 import Config from "../../../Config";
 import { trackUser } from "../../../store/actions/user";
@@ -14,7 +13,7 @@ import { useKeycloakWrapper } from "../../../hooks/useKeycloakWrapper";
 import useConfiguration from "../../../hooks/useConfiguration";
 import { toKebabCase } from "../../../helpers/helpers";
 
-export default function PowerBi(props) {
+export default function PowerBi() {
   const keycloak = useKeycloakWrapper();
   const user = useSelector((state) => state.user);
   const configuration = useConfiguration();
@@ -110,7 +109,6 @@ export default function PowerBi(props) {
 
   useEffect(() => {
     axios.get("/api/opportunity/options").then((data) => {
-      console.log(data);
       const commNames = data.data.communities.map((comm) => comm.place_name);
       const regNames = data.data.regionalDistricts.map((dist) => dist.name);
       setPlaces([...commNames, ...regNames]);
@@ -261,24 +259,6 @@ export default function PowerBi(props) {
                 }
               },
             ],
-            [
-              "bookmarkApplied",
-              function (event) {
-                console.log("filters", event);
-                window.report.getFilters().then((filters) => {
-                  console.log(filters);
-                });
-              },
-            ],
-            [
-              "buttonClicked",
-              function (event) {
-                console.log("button", event);
-                window.report.getFilters().then((filters) => {
-                  console.log(filters);
-                });
-              },
-            ],
           ])
         }
         // // Add CSS classes to the div element
@@ -286,7 +266,6 @@ export default function PowerBi(props) {
         // set report object
         getEmbeddedComponent={(embeddedReport) => {
           window.report = embeddedReport;
-          console.log("embed", embeddedReport);
         }}
       />
     </div>

--- a/cit3.0-web/src/components/Page/PowerBi/PowerBiPublic.js
+++ b/cit3.0-web/src/components/Page/PowerBi/PowerBiPublic.js
@@ -7,7 +7,6 @@ import { models } from "powerbi-client";
 import { useLocation } from "react-router-dom";
 import { Typeahead } from "react-bootstrap-typeahead";
 import Config from "../../../Config";
-import { useKeycloakWrapper } from "../../../hooks/useKeycloakWrapper";
 import { toKebabCase } from "../../../helpers/helpers";
 import useConfiguration from "../../../hooks/useConfiguration";
 

--- a/cit3.0-web/src/components/Page/PowerBi/PowerBiPublic.js
+++ b/cit3.0-web/src/components/Page/PowerBi/PowerBiPublic.js
@@ -1,22 +1,22 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import axios from "axios";
 import "./PowerBi.css";
 import { PowerBIEmbed } from "powerbi-client-react";
+import { Button as ButtonLink, Overlay } from "react-bootstrap";
 import { models } from "powerbi-client";
 import { useLocation } from "react-router-dom";
-import { Button } from "shared-components";
+import { Typeahead } from "react-bootstrap-typeahead";
 import Config from "../../../Config";
 import { useKeycloakWrapper } from "../../../hooks/useKeycloakWrapper";
+import { toKebabCase } from "../../../helpers/helpers";
+import useConfiguration from "../../../hooks/useConfiguration";
 
-export default function PowerBi(props) {
+export default function PowerBi() {
+  const configuration = useConfiguration();
   const [currentPage, setCurrentPage] = useState(null);
   const [currentPageData, setCurrentPageData] = useState(null);
   const [token, setToken] = useState(null);
   const [reportConfig, setReportConfig] = useState(null);
-
-  const keycloak = useKeycloakWrapper();
-  const [loggedIn] = useState(keycloak.obj.authenticated);
-
   const [embedToken, setEmbedToken] = useState(null);
 
   const groupId = Config.pbiGroupId;
@@ -28,6 +28,13 @@ export default function PowerBi(props) {
     new URLSearchParams(search).get("regionalDistrict")
   );
 
+  const [selected, setSelected] = useState("");
+  const [places, setPlaces] = useState(null);
+
+  const [createdUrl, setCreatedUrl] = useState("");
+  const tooltip = useRef(null);
+  const [showToolTip, setShowToolTip] = useState(false);
+
   const filter = () => {
     let result = null;
     if (community) {
@@ -38,7 +45,7 @@ export default function PowerBi(props) {
           column: "Community Name",
         },
         operator: "In",
-        values: [community],
+        values: [community.split("-").join(" ")],
       };
     } else if (regionalDistrict) {
       result = {
@@ -48,7 +55,7 @@ export default function PowerBi(props) {
           column: "Regional District",
         },
         operator: "In",
-        values: [regionalDistrict],
+        values: [regionalDistrict.split("-").join(" ")],
       };
     }
     return result;
@@ -95,19 +102,93 @@ export default function PowerBi(props) {
     }
   }, [reportConfig]);
 
+  useEffect(() => {
+    axios.get("/api/opportunity/options").then((data) => {
+      const commNames = data.data.communities.map((comm) => comm.place_name);
+      const regNames = data.data.regionalDistricts.map((dist) => dist.name);
+      setPlaces([...commNames, ...regNames]);
+    });
+  }, []);
+
   const saveAsPDF = () => {
     window.report.print();
   };
 
+  const createAndCopyLinkToClipboard = () => {
+    const url = `${configuration.baseUrl}/cit-dashboard/public/${toKebabCase(
+      selected
+    )}`;
+    setCreatedUrl(url);
+    const el = document.createElement("textarea");
+    el.value = url;
+    el.setAttribute("readonly", "");
+    el.style.position = "absolute";
+    el.style.left = "-9999px";
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand("copy");
+    document.body.removeChild(el);
+    setShowToolTip(true);
+    setTimeout(() => {
+      setShowToolTip(false);
+    }, 3000);
+  };
+
   return embedToken ? (
     <div id="embed-container">
-      <Button
-        styling={`bcgov-normal-blue btn primary over public ${
-          loggedIn ? "logged-in" : ""
-        }`}
-        label="Save As PDF"
-        onClick={saveAsPDF}
-      />
+      <div className="no-print cit-header">
+        {selected}
+        <ButtonLink
+          variant="link"
+          className="text-white mr-5"
+          onClick={saveAsPDF}
+        >
+          Save As PDF
+        </ButtonLink>
+        {places ? (
+          <>
+            <Typeahead
+              id="typeahead"
+              className="ml-3 mr-3"
+              onChange={(selectedPlace) => {
+                setSelected(selectedPlace[0]);
+              }}
+              value={selected}
+              placeholder="Community name"
+              options={places}
+            />
+            <button
+              disabled={!selected}
+              ref={tooltip}
+              type="button"
+              className="bcgov-normal-blue btn primary over"
+              onClick={createAndCopyLinkToClipboard}
+            >
+              Copy Link
+            </button>
+            <Overlay
+              target={tooltip.current}
+              show={showToolTip}
+              placement="top"
+            >
+              {({ placement, arrowProps, show: _show, popper, ...props2 }) => (
+                <div
+                  {...props2}
+                  style={{
+                    backgroundColor: "#a3c4f5",
+                    padding: "2px 10px",
+                    color: "white",
+                    borderRadius: 3,
+                    ...props2.style,
+                  }}
+                >
+                  Copied to clipboard: {createdUrl}
+                </div>
+              )}
+            </Overlay>
+          </>
+        ) : null}
+      </div>
       <PowerBIEmbed
         embedConfig={{
           type: "report",

--- a/cit3.0-web/src/components/Page/PowerBi/PowerBiPublic.js
+++ b/cit3.0-web/src/components/Page/PowerBi/PowerBiPublic.js
@@ -161,7 +161,7 @@ export default function PowerBi() {
               disabled={!selected}
               ref={tooltip}
               type="button"
-              className="bcgov-normal-blue btn primary over"
+              className="copy-btn btn primary"
               onClick={createAndCopyLinkToClipboard}
             >
               Copy Link

--- a/cit3.0-web/src/components/Page/PropertyDetails2/PropertyDetails2.js
+++ b/cit3.0-web/src/components/Page/PropertyDetails2/PropertyDetails2.js
@@ -27,7 +27,7 @@ import UserFactory from "../../../store/factory/UserFactory";
 export default function PropertyDetails2() {
   const dispatch = useDispatch();
   const [businessContactSync, setBusinessContactSync] = useState(false);
-  const [userInfoSync, setUserInfoSync] = useState(false);
+  // const [userInfoSync, setUserInfoSync] = useState(false);
   const businessContactEmail = useSelector(
     (state) => state.opportunity.businessContactEmail
   );
@@ -99,27 +99,27 @@ export default function PropertyDetails2() {
     dispatch(setBusinessContactEmail(isChecked ? keycloak.email : ""));
   };
 
-  const handleYourInfoCheck = (isChecked) => {
-    setUserInfoSync(isChecked);
-    if (isChecked) {
-      dispatch(setUser(UserFactory.createStateFromKeyCloak(keycloak)));
-      getUser({ email: keycloak.email }).then((response) => {
-        const { data: users } = response;
-        if (users.length) {
-          const appUser = users[0];
-          dispatch(setUser(UserFactory.createStateFromResponse(appUser)));
-        }
-      });
-    } else {
-      dispatch(resetUser());
-    }
-  };
+  // const handleYourInfoCheck = (isChecked) => {
+  //   setUserInfoSync(isChecked);
+  //   if (isChecked) {
+  //     dispatch(setUser(UserFactory.createStateFromKeyCloak(keycloak)));
+  //     getUser({ email: keycloak.email }).then((response) => {
+  //       const { data: users } = response;
+  //       if (users.length) {
+  //         const appUser = users[0];
+  //         dispatch(setUser(UserFactory.createStateFromResponse(appUser)));
+  //       }
+  //     });
+  //   } else {
+  //     dispatch(resetUser());
+  //   }
+  // };
 
-  useEffect(() => {
-    if (userInfoEmail) {
-      setUserInfoSync(true);
-    }
-  }, []);
+  // useEffect(() => {
+  //   if (userInfoEmail) {
+  //     setUserInfoSync(true);
+  //   }
+  // }, []);
 
   return (
     <>
@@ -253,15 +253,16 @@ export default function PropertyDetails2() {
             </span>
           </div>
         </Row>
-        <Row className="mb-3">
+        {/* <Row className="mb-3">
           <Form.Check
-            checked={userInfoSync}
+            checked
+            disabled
             onClick={(e) => handleYourInfoCheck(e.target.checked)}
             type="checkbox"
             label="Use the Contact Name/Email associated with the BCeID logged in."
             aria-label="Use the Contact Name/Email associated with the BCeID logged in."
           />
-        </Row>
+        </Row> */}
         <Row className="mb-4">
           <Col className="pl-0">
             <TextInput
@@ -278,13 +279,14 @@ export default function PropertyDetails2() {
             {!userInfoName && <Validator message="Please enter your name" />}
 
             <p id="email-label" className="mb-0">
-              Email *
+              Email * (This is the email associated with your log in information
+              and cannot be changed)
             </p>
 
             <div className="pb-3">
               <input
                 required
-                disabled={userInfoSync}
+                disabled
                 autoComplete="off"
                 aria-labelledby="email-label"
                 className="bcgov-text-input mb-1 w-100"

--- a/cit3.0-web/src/components/Page/PropertyDetails2/PropertyDetails2.js
+++ b/cit3.0-web/src/components/Page/PropertyDetails2/PropertyDetails2.js
@@ -253,16 +253,6 @@ export default function PropertyDetails2() {
             </span>
           </div>
         </Row>
-        {/* <Row className="mb-3">
-          <Form.Check
-            checked
-            disabled
-            onClick={(e) => handleYourInfoCheck(e.target.checked)}
-            type="checkbox"
-            label="Use the Contact Name/Email associated with the BCeID logged in."
-            aria-label="Use the Contact Name/Email associated with the BCeID logged in."
-          />
-        </Row> */}
         <Row className="mb-4">
           <Col className="pl-0">
             <TextInput

--- a/cit3.0-web/src/components/Page/account/Login.js
+++ b/cit3.0-web/src/components/Page/account/Login.js
@@ -2,11 +2,9 @@ import React from "react";
 import { Redirect } from "react-router-dom";
 import { Container, Row, Col, Spinner, Jumbotron } from "react-bootstrap";
 import { Button } from "shared-components";
-// import { useSelector } from "react-redux";
 import { FaExternalLinkAlt } from "react-icons/fa";
 import { useQuery } from "../../../hooks/use-query";
 import { useKeycloakWrapper } from "../../../hooks/useKeycloakWrapper";
-// import { ADD_ACTIVATE_USER } from "../../../constants/actionTypes";
 
 // @todo: Move to actions / status sources
 // const NEW_CIT_USER = 201;
@@ -26,20 +24,11 @@ const Login = () => {
   const keyCloakWrapper = useKeycloakWrapper();
   const keycloak = keyCloakWrapper.obj;
   const isIE = usingIE();
-  // const activated = useSelector((state) => state.network[ADD_ACTIVATE_USER]);
   if (!keycloak) {
     return <Spinner animation="border" />;
   }
   if (keycloak && keycloak.authenticated) {
-    // if (
-    //   (activated && activated.status === NEW_CIT_USER) ||
-    //   (keyCloakWrapper &&
-    //     keyCloakWrapper.roles &&
-    //     !keyCloakWrapper.roles.length)
-    // ) {
-    //   return <Redirect to={{ pathname: "/access/request" }} />;
-    // }
-    return <Redirect to={redirect || "/search"} />;
+    return <Redirect to={redirect || "/investmentopportunities/dashboard"} />;
   }
   if (isIE) {
     return <Redirect to={{ pathname: "/ienotsupported" }} />;

--- a/cit3.0-web/src/components/Page/citHome/citHome.js
+++ b/cit3.0-web/src/components/Page/citHome/citHome.js
@@ -9,6 +9,7 @@ import axios from "axios";
 import { Typeahead } from "react-bootstrap-typeahead";
 import { useKeycloakWrapper } from "../../../hooks/useKeycloakWrapper";
 import useConfiguration from "../../../hooks/useConfiguration";
+import { toKebabCase } from "../../../helpers/helpers";
 
 export default function citHome() {
   const [selectedPlace, setSelectedPlace] = useState(null);
@@ -58,7 +59,7 @@ export default function citHome() {
   const handlePublic = () => {
     if (selectedPlace) {
       const type = typeOfSelected(selectedPlace);
-      history.push(`${publicUrl}?${type}=${selectedPlace}`);
+      history.push(`${publicUrl}?${type}=${toKebabCase(selectedPlace)}`);
     } else {
       history.push(publicUrl);
     }
@@ -72,7 +73,9 @@ export default function citHome() {
       loginWithIdir = keycloak.obj.createLoginUrl({
         idpHint: "idir",
         redirectUri: encodeURI(
-          `${configuration.baseUrl}${privateUrl}?${type}=${selectedPlace}`
+          `${configuration.baseUrl}${privateUrl}?${type}=${toKebabCase(
+            selectedPlace
+          )}`
         ),
       });
     } else {

--- a/cit3.0-web/src/components/SearchFlyoutContent/SearchFlyoutContent.scss
+++ b/cit3.0-web/src/components/SearchFlyoutContent/SearchFlyoutContent.scss
@@ -26,6 +26,8 @@
 }
 
 .search-flyout-content {
+  width: 100%;
+  overflow-x: hidden;
   h3 {
     padding-top: 10px;
     padding-bottom: 10px;


### PR DESCRIPTION
- Header does not show logged in sub header for CIT pages
- save to pdf is now link in sub header
- user can select a community/regional district and get a link copied to clipboard for the public view for that page (CIT-232)
-also removed horizontal scroll bar in searchFlyout  (part of cit-348)

- this PR also refactors the login/logout redirect and ensures it is congruent with the page origin.  
- login for coit still shows both idir and bceid options, cit only allows login with idir

- this PR also removes the ability to uncheck email/name from PropDetails2 - email field is disabled and unable to be changed