### PR TITLE
Fixes - back button on Opportunity page and clear up warnings

### DIFF
--- a/cit3.0-web/src/components/LocationsPanel/LocationsPanel.js
+++ b/cit3.0-web/src/components/LocationsPanel/LocationsPanel.js
@@ -45,7 +45,7 @@ const LocationsPanel = ({
             <Row key={v4()} className="d-flex justify-content-between">
               <Col className="pl-0">
                 <a
-                  style={{ "line-height": "2rem" }}
+                  style={{ lineHeight: "2rem" }}
                   target="_blank"
                   rel="noreferrer"
                   href={`${muni.link}`}

--- a/cit3.0-web/src/components/Map/Map.js
+++ b/cit3.0-web/src/components/Map/Map.js
@@ -110,7 +110,7 @@ export default function Map({
             />
           </LayersControl.BaseLayer>
 
-          <LayersControl.Overlay name="Parcels">
+          <LayersControl.Overlay checked name="Parcels">
             <WMSTileLayer
               version="1.3.0"
               transparent="true"

--- a/cit3.0-web/src/components/OpportunityListItem/OpportunityListItem.js
+++ b/cit3.0-web/src/components/OpportunityListItem/OpportunityListItem.js
@@ -26,7 +26,7 @@ const OpportunityListItem = ({ opportunity, publicView, handleModalOpen }) => {
           editing: true,
         })
       );
-      history.push("/investmentopportunities/");
+      history.push("/investmentopportunities/add");
     });
   };
   const determineActions = (opp) => {
@@ -109,7 +109,14 @@ const OpportunityListItem = ({ opportunity, publicView, handleModalOpen }) => {
             ) : (
               <Col className="d-flex align-items-end justify-content-end mr-1">
                 {publicView && (
-                  <Link to={opportunity.link}>View property details</Link>
+                  <Link
+                    to={{
+                      pathname: opportunity.link,
+                      state: { prevPath: window.location.pathname },
+                    }}
+                  >
+                    View property details
+                  </Link>
                 )}
               </Col>
             )}

--- a/cit3.0-web/src/components/OpportunityView/OpportunityView.js
+++ b/cit3.0-web/src/components/OpportunityView/OpportunityView.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import { Alert } from "shared-components";
 import { MdInfo } from "react-icons/md";
+import { v4 } from "uuid";
 import Resource from "./Resource";
 import LocationsPanel from "../LocationsPanel/LocationsPanel";
 import BusinessContact from "../BusinessContact/BusinessContact";
@@ -59,6 +60,7 @@ export default function OpportunityView({ view }) {
           {overallInfo && (
             <>
               <Resource
+                key={v4()}
                 title="Site Info - General Details"
                 itemsToDisplay={overallInfo}
               />
@@ -72,11 +74,19 @@ export default function OpportunityView({ view }) {
               </div>
             </>
           )}
-          {physical && <Resource title="Physical" itemsToDisplay={physical} />}
-          {transportation && (
-            <Resource title="Transportation" itemsToDisplay={transportation} />
+          {physical && (
+            <Resource key={v4()} title="Physical" itemsToDisplay={physical} />
           )}
-          {services && <Resource title="Services" itemsToDisplay={services} />}
+          {transportation && (
+            <Resource
+              key={v4()}
+              title="Transportation"
+              itemsToDisplay={transportation}
+            />
+          )}
+          {services && (
+            <Resource key={v4()} title="Services" itemsToDisplay={services} />
+          )}
         </Col>
         <Col xs lg="5" className="leaflet-border pr-0">
           <div

--- a/cit3.0-web/src/components/OpportunityView/OpportunityView.js
+++ b/cit3.0-web/src/components/OpportunityView/OpportunityView.js
@@ -62,7 +62,7 @@ export default function OpportunityView({ view }) {
                 title="Site Info - General Details"
                 itemsToDisplay={overallInfo}
               />
-              <div style={{ "margin-left": "-15px", "margin-right": "-15px" }}>
+              <div style={{ marginLeft: "-15px", marginRight: "-15px" }}>
                 <Alert
                   icon={<MdInfo size={32} />}
                   type="info"

--- a/cit3.0-web/src/components/Page/OpportunityPage/OpportunityPage.js
+++ b/cit3.0-web/src/components/Page/OpportunityPage/OpportunityPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import Proptypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation, useHistory } from "react-router-dom";
@@ -34,10 +34,19 @@ const OpportunityPage = ({ id }) => {
     }
   }, []);
 
+  // catch the previous path sent from the search page if it exists and route to there
+  useEffect(() => {
+    if (location.state) {
+      if (location.state.prevPath) {
+        history.push(location.state.prevPath);
+      }
+    }
+  });
+
   const resetState = (e) => {
+    e.preventDefault();
     history.goBack();
     dispatch(resetOpportunity());
-    e.preventDefault();
   };
 
   // Copy the visually hidden textarea
@@ -66,12 +75,14 @@ const OpportunityPage = ({ id }) => {
       <Container className="p-0 mt-3">
         <Row className="no-print">
           <Col className="align-self-end">
-            <Button
-              label="Go Back to Search"
-              styling="bcgov-normal-blue btn px-4"
-              onClick={resetState}
-              onKeyDown={resetState}
-            />
+            {history.action !== "POP" && (
+              <Button
+                label="Back"
+                styling="bcgov-normal-blue btn px-4"
+                onClick={resetState}
+                onKeyDown={resetState}
+              />
+            )}
             <textarea
               readOnly
               id="link"
@@ -113,6 +124,7 @@ const OpportunityPage = ({ id }) => {
 
       <Container className="p-0 no-print">
         <Alert
+          icon={<></>}
           type="warning"
           styling="bcgov-warning-background mb-4"
           element="Property listings on this site include information provided by authorized community representatives and obtained from open data sources. The Province of British Columbia has not verified the information and prospective purchasers, lessors and others should conduct their own usual due diligence and make such enquiries as they deem necessary before purchasing, leasing or otherwise investing in the subject site. Prospective purchasers, lessors and other interested in the subject site should check existing laws and regulations to confirm that this particular property is suitable for their intended purpose or use and what permits, approvals and consultations, including with Indigenous communities, are required in order to develop such property, as well as any costs associated with such development. Listings are for information purposes only and are not intended to provide investment advice. Reliance upon any information shall be at the user’s sole risk. All information should be verified independently before being used or relied upon. The Province of British Columbia does not guarantee the quality, accuracy, completeness or timeliness of this information; and assumes no obligation to update this information or advise on further developments. The Province of British Columbia disclaims any liability for unauthorized use or reproduction of any information contained in this document and is not responsible for any direct, indirect, special or consequential damages or any other damages caused, arising out of or in connection with use of this information. The Province of British Columbia is not acting as a real estate broker or agent for any party in connection with any of the properties described on this website."

--- a/cit3.0-web/src/components/Page/PropertyDetails2/PropertyDetails2.js
+++ b/cit3.0-web/src/components/Page/PropertyDetails2/PropertyDetails2.js
@@ -259,6 +259,7 @@ export default function PropertyDetails2() {
               <input
                 required
                 disabled
+                readOnly
                 autoComplete="off"
                 aria-labelledby="email-label"
                 className="bcgov-text-input mb-1 w-100"

--- a/cit3.0-web/src/components/Page/SiteInformation/SiteInformation.js
+++ b/cit3.0-web/src/components/Page/SiteInformation/SiteInformation.js
@@ -21,6 +21,7 @@ export default function SiteInformation({ location }) {
       <NavigationHeader currentStep={2} />
       <Container className="p-0 mt-3">
         <Alert
+          icon={<></>}
           type="warning"
           styling="bcgov-warning-background"
           element="Your listing will include the following location and proximity data available from open data sources. You will be able to add additional data to your listing in the next steps, including site servicing information. The remainder of the information is not editable and is provided for reference only. Proximity details are provided in straight-line distances. All information should be verified independently before being used or relied upon. The Province of British Columbia does not guarantee the quality, accuracy, completeness or timeliness of this information."


### PR DESCRIPTION
- several small fixes to remove warnings
- rename back to search button to simply "back" as a user may be coming from the EDO dashboard
- page does not show back button if the link is from external source (ie copied/pasted to browser)
- page successfully re-routes to search page on first try