### PR TITLE
handle '.' error - geocoder returns unparseable json data when a peri…

### DIFF
--- a/cit3.0-web/src/components/AddressSearchBar/AddressSearchBar.js
+++ b/cit3.0-web/src/components/AddressSearchBar/AddressSearchBar.js
@@ -21,8 +21,6 @@ export default function AddressSearchBar({
     setAddress(event.target.value);
     try {
       const addressData = await getAddressData(event.target.value);
-      console.log(addressData);
-      console.log(typeof addressData.data);
       if (typeof addressData.data === "string") {
         return false;
       }

--- a/cit3.0-web/src/components/AddressSearchBar/AddressSearchBar.js
+++ b/cit3.0-web/src/components/AddressSearchBar/AddressSearchBar.js
@@ -21,6 +21,11 @@ export default function AddressSearchBar({
     setAddress(event.target.value);
     try {
       const addressData = await getAddressData(event.target.value);
+      console.log(addressData);
+      console.log(typeof addressData.data);
+      if (typeof addressData.data === "string") {
+        return false;
+      }
       setAddresses(addressData.data.features);
       setLocalityName(addressData.data.features[0].properties.localityName);
       return true;


### PR DESCRIPTION
…od is passed in. Subsequent characters return objects again