### PR TITLE
Datasources

### DIFF
--- a/cit3.0-web/src/App.js
+++ b/cit3.0-web/src/App.js
@@ -244,7 +244,10 @@ function App() {
                   component={HomePage}
                 />
                 <AppRoute path="/cit-dashboard/home" component={citHome} />
-                <AppRoute path="/datasources" component={Datasources} />
+                <AppRoute
+                  path="/investmentopportunities/datasources"
+                  component={Datasources}
+                />
               </Switch>
               <div className="footer">
                 <Footer />

--- a/cit3.0-web/src/components/AddressSearchBar/AddressSearchBar.js
+++ b/cit3.0-web/src/components/AddressSearchBar/AddressSearchBar.js
@@ -21,8 +21,6 @@ export default function AddressSearchBar({
     setAddress(event.target.value);
     try {
       const addressData = await getAddressData(event.target.value);
-      console.log(addressData);
-      console.log(typeof addressData.data);
       if (typeof addressData.data === "string") {
         return false;
       }

--- a/cit3.0-web/src/components/AddressSearchBar/AddressSearchBar.js
+++ b/cit3.0-web/src/components/AddressSearchBar/AddressSearchBar.js
@@ -21,6 +21,11 @@ export default function AddressSearchBar({
     setAddress(event.target.value);
     try {
       const addressData = await getAddressData(event.target.value);
+      console.log(addressData);
+      console.log(typeof addressData.data);
+      if (typeof addressData.data === "string") {
+        return false;
+      }
       setAddresses(addressData.data.features);
       setLocalityName(addressData.data.features[0].properties.localityName);
       return true;

--- a/cit3.0-web/src/components/Page/Datasources/Datasources.js
+++ b/cit3.0-web/src/components/Page/Datasources/Datasources.js
@@ -3,33 +3,13 @@ import Table from "react-bootstrap/Table";
 
 const elements = [
   {
-    "Data Source": "Census",
+    "Data Source": "BC Airports",
     "Metadata URL":
-      "https://www12.statcan.gc.ca/rest/census-recensement/CPR2016.json?",
+      "https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8",
   },
   {
-    "Data Source": "Civic Facilities",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/ea7cd54f-1820-4f4a-8b2c-40c8a51f84bd",
-  },
-  {
-    "Data Source": "Civic_leaders",
-    "Metadata URL": "https://www.civicinfo.bc.ca/people",
-  },
-  {
-    "Data Source": "Communities",
-    "Metadata URL":
-      "https://open.canada.ca/data/en/dataset/fe945388-1dd9-4a4a-9a1e-5c552579a28c",
-  },
-  {
-    "Data Source": "Court Locations",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/c95a2ad5-f62a-43d6-8678-80a617b6200e",
-  },
-  {
-    "Data Source": "Current Census Regions",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/1aebc451-a41c-496f-8b18-6f414cde93b7",
+    "Data Source": "Census Profiles (2016)",
+    "Metadata URL": "https://catalogue.data.gov.bc.ca/group/census-profiles",
   },
   {
     "Data Source": "Customs Port of Entry",
@@ -37,24 +17,14 @@ const elements = [
       "https://catalogue.data.gov.bc.ca/dataset/4fac3ad6-8749-4741-ac98-527b23e4b0b2",
   },
   {
-    "Data Source": "Diagnostic Facilities",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/4f75e9f6-1459-4ae2-990d-b53b1c389525",
-  },
-  {
     "Data Source": "Digital Road Atlas (DRA)",
     "Metadata URL":
       "https://catalogue.data.gov.bc.ca/dataset/bb060417-b6e6-4548-b837-f9060d94743e",
   },
   {
-    "Data Source": "Emergency Social Services Facilities",
+    "Data Source": "Elevation (from Soils data)",
     "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/8473689f-2d06-4e84-ac8b-e91033fd0f0b",
-  },
-  {
-    "Data Source": "Environmental Assessment Office (EAO) Points",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/bc1c5380-6fca-4666-996b-049ad8ca04cc",
+      "https://catalogue.data.gov.bc.ca/dataset/20150a67-5a2d-425f-8216-ff0f97f68df9",
   },
   {
     "Data Source": "First Nations Reserves",
@@ -77,14 +47,9 @@ const elements = [
       "https://catalogue.data.gov.bc.ca/dataset/f7dac054-efbf-402f-ab62-6fc4b32a619e",
   },
   {
-    "Data Source": "Health Authority Boundaries",
+    "Data Source": "Geolocated Placenames (Communities)",
     "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/7bc6018f-bb4f-4e5d-845e-c529e3d1ac3b",
-  },
-  {
-    "Data Source": "Hexagonal Grid",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/a3badeec-feed-41d9-b33d-5ae41c19f27d",
+      "https://open.canada.ca/data/en/dataset/fe945388-1dd9-4a4a-9a1e-5c552579a28c",
   },
   {
     "Data Source": "Hospitals",
@@ -92,48 +57,18 @@ const elements = [
       "https://catalogue.data.gov.bc.ca/dataset/383eaf98-afd7-436a-9556-67ecf14f64a7",
   },
   {
-    "Data Source": "Laboratory Services in BC",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/401671c5-4fc4-4ffb-9e29-0cdc3c9433ba",
-  },
-  {
-    "Data Source": "Local Government Offices",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/0fe8083a-881a-4fa8-8925-3a23b788e1b9",
-  },
-  {
-    "Data Source": "Major Timber Processing Facilities",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/67daf53d-e3bb-45ee-9121-8aa1193b7492",
-  },
-  {
-    "Data Source": "Major Projects",
-    "Metadata URL":
-      "https://www2.gov.bc.ca/gov/content/employment-business/economic-development/industry/bc-major-projects-inventory",
-  },
-  {
-    "Data Source": "Mapped Floodplains (Historical)",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/cdf4900e-90c0-449f-beea-43b669bd76a8",
-  },
-  {
     "Data Source": "Municipalities",
     "Metadata URL":
       "https://catalogue.data.gov.bc.ca/dataset/e3c3c580-996a-4668-8bc5-6aa7c7dc4932",
-  },
-  {
-    "Data Source": "Natural Resource Regions",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/dfc492c0-69c5-4c20-a6de-2c9bc999301f",
   },
   {
     "Data Source": "Northern Rockies Census Division",
     "Metadata URL": "",
   },
   {
-    "Data Source": "Permitted Mine Areas  - Major Mines",
+    "Data Source": "ParcelMap BC",
     "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/01e8a35e-35e3-4b48-93a7-b0d7c9705b62",
+      "https://catalogue.data.gov.bc.ca/dataset/29a6171a-fab6-4644-b0f7-5d4e466f6837",
   },
   {
     "Data Source": "Ports and Terminals",
@@ -144,11 +79,6 @@ const elements = [
     "Data Source": "Post Secondary Institutions",
     "Metadata URL":
       "https://catalogue.data.gov.bc.ca/dataset/81558d54-1f96-46c2-94fe-56d26f69c4f5",
-  },
-  {
-    "Data Source": "Provincial Electoral Districts",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/9530a41d-6484-41e5-b694-acb76e212a58",
   },
   {
     "Data Source": "Railway Track",
@@ -171,34 +101,14 @@ const elements = [
       "https://open.canada.ca/data/en/dataset/00a331db-121b-445d-b119-35dbbe3eedd9",
   },
   {
-    "Data Source": "School Districts",
+    "Data Source": "Soils Survey",
     "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/78ec5279-4534-49a1-97e8-9d315936f08b",
-  },
-  {
-    "Data Source": "Schools K-12",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/95da1091-7e8c-4aa6-9c1b-5ab159ea7b42",
-  },
-  {
-    "Data Source": "Service BC Locations",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/2b44d212-5438-47a9-ad23-20eb8ada9709",
-  },
-  {
-    "Data Source": "Tourism Room Revenues and Property Counts",
-    "Metadata URL":
-      "https://www2.gov.bc.ca/gov/content/data/statistics/business-industry-trade/industry/tourism",
+      "https://catalogue.data.gov.bc.ca/dataset/20150a67-5a2d-425f-8216-ff0f97f68df9",
   },
   {
     "Data Source": "Tsunami Notification Zones",
     "Metadata URL":
       "https://catalogue.data.gov.bc.ca/dataset/d9bafe48-5bf7-461b-a8d6-ba6d1e2245f0",
-  },
-  {
-    "Data Source": "Walk-in Clinics",
-    "Metadata URL":
-      "https://catalogue.data.gov.bc.ca/dataset/5e2707c3-0aa4-4d2d-aedc-4dd0914b686a",
   },
   {
     "Data Source": "Wildfire Wildland Urban Interface Risk Class",

--- a/cit3.0-web/src/components/Page/OpportunityPage/OpportunityPage.js
+++ b/cit3.0-web/src/components/Page/OpportunityPage/OpportunityPage.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Proptypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation, useHistory } from "react-router-dom";
+import { useLocation, useHistory, Link } from "react-router-dom";
 import { Button } from "shared-components";
 import { Alert } from "shared-components/build/components/alert/Alert";
 import { Col, Container, Row } from "react-bootstrap";
@@ -135,7 +135,43 @@ const OpportunityPage = ({ id }) => {
           icon={<></>}
           type="warning"
           styling="bcgov-warning-background mb-4"
-          element="Property listings on this site include information provided by authorized community representatives and obtained from open data sources. The Province of British Columbia has not verified the information and prospective purchasers, lessors and others should conduct their own usual due diligence and make such enquiries as they deem necessary before purchasing, leasing or otherwise investing in the subject site. Prospective purchasers, lessors and other interested in the subject site should check existing laws and regulations to confirm that this particular property is suitable for their intended purpose or use and what permits, approvals and consultations, including with Indigenous communities, are required in order to develop such property, as well as any costs associated with such development. Listings are for information purposes only and are not intended to provide investment advice. Reliance upon any information shall be at the user’s sole risk. All information should be verified independently before being used or relied upon. The Province of British Columbia does not guarantee the quality, accuracy, completeness or timeliness of this information; and assumes no obligation to update this information or advise on further developments. The Province of British Columbia disclaims any liability for unauthorized use or reproduction of any information contained in this document and is not responsible for any direct, indirect, special or consequential damages or any other damages caused, arising out of or in connection with use of this information. The Province of British Columbia is not acting as a real estate broker or agent for any party in connection with any of the properties described on this website."
+          element={
+            <span>
+              Property listings on this site include information provided by
+              authorized community representatives and obtained from{" "}
+              <span>
+                {" "}
+                <Link to="/investmentopportunities/datasources">
+                  open data sources.
+                </Link>
+              </span>{" "}
+              The Province of British Columbia has not verified the information
+              and prospective purchasers, lessors and others should conduct
+              their own usual due diligence and make such enquiries as they deem
+              necessary before purchasing, leasing or otherwise investing in the
+              subject site. Prospective purchasers, lessors and other interested
+              in the subject site should check existing laws and regulations to
+              confirm that this particular property is suitable for their
+              intended purpose or use and what permits, approvals and
+              consultations, including with Indigenous communities, are required
+              in order to develop such property, as well as any costs associated
+              with such development. Listings are for information purposes only
+              and are not intended to provide investment advice. Reliance upon
+              any information shall be at the user’s sole risk. All information
+              should be verified independently before being used or relied upon.
+              The Province of British Columbia does not guarantee the quality,
+              accuracy, completeness or timeliness of this information; and
+              assumes no obligation to update this information or advise on
+              further developments. The Province of British Columbia disclaims
+              any liability for unauthorized use or reproduction of any
+              information contained in this document and is not responsible for
+              any direct, indirect, special or consequential damages or any
+              other damages caused, arising out of or in connection with use of
+              this information. The Province of British Columbia is not acting
+              as a real estate broker or agent for any party in connection with
+              any of the properties described on this website.
+            </span>
+          }
         />
       </Container>
     </div>

--- a/cit3.0-web/src/components/Page/SiteInformation/SiteInformation.js
+++ b/cit3.0-web/src/components/Page/SiteInformation/SiteInformation.js
@@ -1,8 +1,7 @@
 import PropTypes from "prop-types";
-import { useHistory } from "react-router-dom";
+import { useHistory, Link } from "react-router-dom";
 import { Container } from "react-bootstrap";
 import { Alert } from "shared-components";
-import { MdError } from "react-icons/md";
 import { useDispatch } from "react-redux";
 
 import NavigationHeader from "../../Headers/NavigationHeader/NavigationHeader";
@@ -32,7 +31,26 @@ export default function SiteInformation({ location }) {
           icon={<></>}
           type="warning"
           styling="bcgov-warning-background"
-          element="Your listing will include the following location and proximity data available from open data sources. You will be able to add additional data to your listing in the next steps, including site servicing information. The remainder of the information is not editable and is provided for reference only. Proximity details are provided in straight-line distances. All information should be verified independently before being used or relied upon. The Province of British Columbia does not guarantee the quality, accuracy, completeness or timeliness of this information."
+          element={
+            <span>
+              Your listing will include the following location and proximity
+              data available from
+              <span>
+                {" "}
+                <Link to="/investmentopportunities/datasources">
+                  open data sources.
+                </Link>
+              </span>{" "}
+              You will be able to add additional data to your listing in the
+              next steps, including site servicing information. The remainder of
+              the information is not editable and is provided for reference
+              only. Proximity details are provided in straight-line distances.
+              All information should be verified independently before being used
+              or relied upon. The Province of British Columbia does not
+              guarantee the quality, accuracy, completeness or timeliness of
+              this information.
+            </span>
+          }
         />
       </Container>
       <OpportunityView data={location.state} />


### PR DESCRIPTION
- Removed CIT datasources as CIT has its own PowerBI tab for sources.  Current data sources are the ones represented by COIT.  Added sources not listed from main list
- Update route from /datasources to /investmentopportunities/datasources
- add Links to Site-Info and Opportunity page where "open data sources" are mentioned
