### PR TITLE
Contact us

### DIFF
--- a/cit3.0-web/src/App.js
+++ b/cit3.0-web/src/App.js
@@ -5,7 +5,7 @@ import { BrowserRouter as Router, Switch, Redirect } from "react-router-dom";
 import "./App.css";
 import LoadingBar from "react-redux-loading-bar";
 import { Spinner } from "react-bootstrap";
-import { Footer } from "./components/Footer/Footer";
+import Footer from "./components/Footer/Footer";
 import Header from "./components/Headers/Header/Header";
 
 import OpportunityApprovePage from "./components/Page/OpportunityApprovePage/OpportunityApprovePage";

--- a/cit3.0-web/src/App.js
+++ b/cit3.0-web/src/App.js
@@ -3,9 +3,9 @@ import "@bcgov/bootstrap-theme/dist/css/bootstrap-theme.min.css";
 
 import { BrowserRouter as Router, Switch, Redirect } from "react-router-dom";
 import "./App.css";
-import { Footer } from "shared-components";
 import LoadingBar from "react-redux-loading-bar";
 import { Spinner } from "react-bootstrap";
+import { Footer } from "./components/Footer/Footer";
 import Header from "./components/Headers/Header/Header";
 
 import OpportunityApprovePage from "./components/Page/OpportunityApprovePage/OpportunityApprovePage";

--- a/cit3.0-web/src/components/Footer/Footer.js
+++ b/cit3.0-web/src/components/Footer/Footer.js
@@ -1,0 +1,56 @@
+export const LinkElement = (url, label) => (
+  <li className="nav-item m-1">
+    <a
+      className="nav-link"
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {label}
+    </a>
+  </li>
+);
+
+export const FooterToggler = () => (
+  <button
+    className="navbar-toggler"
+    type="button"
+    data-toggle="collapse"
+    data-target="#footerBar"
+  >
+    <span className="navbar-toggler-icon" />
+  </button>
+);
+
+export const Footer = () => (
+  <footer className="bcgov-footer">
+    <nav
+      className="navbar navbar-expand-sm navbar-dark justify-content-end"
+      aria-label="Footer"
+    >
+      <FooterToggler />
+      <div className="collapse navbar-collapse flex-grow-0" id="footerBar">
+        <ul className="navbar-nav text-right">
+          {LinkElement("mailto:citinfo@gov.bc.ca", "Contact Us")}
+          {LinkElement("https://www2.gov.bc.ca", "BC Government")}
+          {LinkElement(
+            "https://www2.gov.bc.ca/gov/content/home/disclaimer",
+            "Disclaimer"
+          )}
+          {LinkElement(
+            "https://www2.gov.bc.ca/gov/content/home/privacy",
+            "Privacy"
+          )}
+          {LinkElement(
+            "https://www2.gov.bc.ca/gov/content/home/accessibility",
+            "Accessibility"
+          )}
+          {LinkElement(
+            "https://www2.gov.bc.ca/gov/content/home/copyright",
+            "Copyright"
+          )}
+        </ul>
+      </div>
+    </nav>
+  </footer>
+);

--- a/cit3.0-web/src/components/Footer/Footer.js
+++ b/cit3.0-web/src/components/Footer/Footer.js
@@ -1,4 +1,4 @@
-export const LinkElement = (url, label) => (
+const LinkElement = (url, label) => (
   <li className="nav-item m-1">
     <a
       className="nav-link"
@@ -11,7 +11,7 @@ export const LinkElement = (url, label) => (
   </li>
 );
 
-export const FooterToggler = () => (
+const FooterToggler = () => (
   <button
     className="navbar-toggler"
     type="button"
@@ -22,35 +22,37 @@ export const FooterToggler = () => (
   </button>
 );
 
-export const Footer = () => (
-  <footer className="bcgov-footer">
-    <nav
-      className="navbar navbar-expand-sm navbar-dark justify-content-end"
-      aria-label="Footer"
-    >
-      <FooterToggler />
-      <div className="collapse navbar-collapse flex-grow-0" id="footerBar">
-        <ul className="navbar-nav text-right">
-          {LinkElement("mailto:citinfo@gov.bc.ca", "Contact Us")}
-          {LinkElement("https://www2.gov.bc.ca", "BC Government")}
-          {LinkElement(
-            "https://www2.gov.bc.ca/gov/content/home/disclaimer",
-            "Disclaimer"
-          )}
-          {LinkElement(
-            "https://www2.gov.bc.ca/gov/content/home/privacy",
-            "Privacy"
-          )}
-          {LinkElement(
-            "https://www2.gov.bc.ca/gov/content/home/accessibility",
-            "Accessibility"
-          )}
-          {LinkElement(
-            "https://www2.gov.bc.ca/gov/content/home/copyright",
-            "Copyright"
-          )}
-        </ul>
-      </div>
-    </nav>
-  </footer>
-);
+export default function Footer() {
+  return (
+    <footer className="bcgov-footer">
+      <nav
+        className="navbar navbar-expand-sm navbar-dark justify-content-end"
+        aria-label="Footer"
+      >
+        <FooterToggler />
+        <div className="collapse navbar-collapse flex-grow-0" id="footerBar">
+          <ul className="navbar-nav text-right">
+            {LinkElement("mailto:citinfo@gov.bc.ca", "Contact Us")}
+            {LinkElement("https://www2.gov.bc.ca", "BC Government")}
+            {LinkElement(
+              "https://www2.gov.bc.ca/gov/content/home/disclaimer",
+              "Disclaimer"
+            )}
+            {LinkElement(
+              "https://www2.gov.bc.ca/gov/content/home/privacy",
+              "Privacy"
+            )}
+            {LinkElement(
+              "https://www2.gov.bc.ca/gov/content/home/accessibility",
+              "Accessibility"
+            )}
+            {LinkElement(
+              "https://www2.gov.bc.ca/gov/content/home/copyright",
+              "Copyright"
+            )}
+          </ul>
+        </div>
+      </nav>
+    </footer>
+  );
+}


### PR DESCRIPTION
Add contact us to footer - as we were formerly using shared-component had to create our own footer (poached from shared-components)