### PR TITLE
fix modal bug that kept asking without letting a close and continue

### DIFF
--- a/cit3.0-web/src/components/OpportunityApproveCallout/OpportunityApproveCallout.js
+++ b/cit3.0-web/src/components/OpportunityApproveCallout/OpportunityApproveCallout.js
@@ -38,6 +38,7 @@ const OpportunityApproveCallout = ({
   const opportunityName = useSelector((state) => state.opportunity.name);
   const opportunityId = useSelector((state) => state.opportunity.id);
   const keycloak = useKeycloakWrapper();
+  const [asked, setAsked] = useState(false);
 
   const [show, setShow] = useState(false);
 
@@ -114,9 +115,11 @@ const OpportunityApproveCallout = ({
     if (
       nextStatus !== currentStatus && // status has changed
       newPublicNote !== "" && // comment box is not empty
-      publicNote === newPublicNote // comment has not changed
+      publicNote === newPublicNote && // comment has not changed
+      asked === false
     ) {
       handleShow();
+      setAsked(true);
     } else {
       submitStatusChange();
     }


### PR DESCRIPTION
If the user didn't delete the comment the user would continually be asked to delete it without being allowed to continue to saving it.  Fixed.  User is asked once only if they want to delete.