### PR TITLE
CIT-469- Error message when user doesn't select address from drop down list

### DIFF
--- a/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
+++ b/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
@@ -18,6 +18,7 @@ import {
   getPID,
   getParcelDataNoAddress,
 } from "../../../helpers/parcelData";
+import { COORDINATE } from "../../../constants/coordinate";
 import {
   setAddress,
   setCoords,
@@ -79,6 +80,11 @@ export default function AddOpportunity() {
   // handle proximity data still loading modal
   const [proxModalShow, setProxModalShow] = useState(false);
 
+  const isInvalidAddress =
+    (!address || !localityName) &&
+    coords[0] === COORDINATE.X &&
+    coords[1] === COORDINATE.Y;
+
   const showProximityModal = () => {
     setChangePage(true);
     setProxModalShow(true);
@@ -105,7 +111,7 @@ export default function AddOpportunity() {
       }
     }
     handleClose();
-    if (proximityInProgress && !error.length) {
+    if (proximityInProgress && !error.length && !isInvalidAddress) {
       showProximityModal();
     }
   };
@@ -139,13 +145,12 @@ export default function AddOpportunity() {
     setError([]);
     let errors = [];
     let warnings = [];
-
     if (!address || !geometry) {
       warnings = [
         ...warnings,
-        `This opportunity has no ${!address ? "address" : ""}${
-          !address && !geometry ? " or " : ""
-        }${!geometry ? "parcel" : ""} associated with it.`,
+        `${isInvalidAddress ? "Please enter a valid address" : ""}${
+          isInvalidAddress && !geometry ? " or " : ""
+        }${!geometry ? "select a land parcel from the map to continue." : ""}`,
       ];
     }
     if (parcelOwner === "Private" && hasApproval !== "Yes") {

--- a/cit3.0-web/src/constants/coordinate.js
+++ b/cit3.0-web/src/constants/coordinate.js
@@ -1,0 +1,9 @@
+/**
+ * Default coordinate, center of the province of BC.
+ */
+export const COORDINATE = {
+  X: 54.1722,
+  Y: -124.1207,
+};
+
+export default COORDINATE;


### PR DESCRIPTION
When user does not select address from drop down list OR does not type a valid address and click on Continue, a modal window pops up forever waiting for a valid address.
![image](https://user-images.githubusercontent.com/10526131/219496040-214bfbee-01ce-4ad0-85bb-9e336baf2eab.png)

With the current fix, the warning message is updated and modal window is not showing up to allow typing a valid address:
![image](https://user-images.githubusercontent.com/10526131/219496615-ec98b972-3a1d-4294-8a38-05d7ccadb19f.png)


https://connectivitydivision.atlassian.net/browse/CIT-469