### PR TITLE
Upgraded API Python from 3.6 to 3.9

### DIFF
--- a/cit-api/Dockerfile.dev
+++ b/cit-api/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.9
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && apt-get install -y libproj-dev gdal-bin libpq-dev libpython3-dev build-essential

--- a/cit-api/pipeline/views/email.py
+++ b/cit-api/pipeline/views/email.py
@@ -18,7 +18,7 @@ class EmailView(APIView):
         request_body = request.data
         opportunity_id = request_body.get("id", -1)
         opportunity_link = request_body.get("link", None)
-        if opportunity_link is not None and opportunity_id is not -1:
+        if opportunity_link is not None and opportunity_id != -1:
             token_request_body = {'grant_type': 'client_credentials'}
             response = requests.post(os.environ.get("EMAIL_AUTH_HOST"), data=token_request_body, auth=HTTPBasicAuth(os.environ.get("EMAIL_CLIENT_ID"),os.environ.get("EMAIL_CLIENT_SECRET")))       
             if response.status_code == 200:
@@ -76,7 +76,7 @@ class EdoEmailView(APIView):
         request_body = request.data
         opportunity_id = request_body.get("id", -1)
         opportunity_link = request_body.get("link", None)
-        if opportunity_link is not None and opportunity_id is not -1:
+        if opportunity_link is not None and opportunity_id != -1:
             token_request_body = {'grant_type': 'client_credentials'}
             response = requests.post(os.environ.get("EMAIL_AUTH_HOST"), data=token_request_body, auth=HTTPBasicAuth(os.environ.get("EMAIL_CLIENT_ID"),os.environ.get("EMAIL_CLIENT_SECRET")))
             if response.status_code == 200:

--- a/cit3.0-web/.gitignore
+++ b/cit3.0-web/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.yarn
 /.pnp
 .pnp.js
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: cittest1
+      POSTGRES_DB: cit
       POSTGRES_MULTIPLE_EXTENSIONS: postgis,pgrouting,pg_buffercache,pg_stat_statements
     volumes:
       - ./db/init.sql:/usr/share/postgresql/15/contrib/postgis-3.3/legacy_minimal.sql


### PR DESCRIPTION
After upgrading Python from 3.6 to 3.9 results;

- 2 warnings from email.py regarding using "is not" with a literal. Updated to use "!="
- API service enters running state and GET operations from Swagger retrieve data without issue 