### PR TITLE
CIT-573: Delete Opportunity

### DIFF
--- a/cit-api/pipeline/views/opportunity/edit.py
+++ b/cit-api/pipeline/views/opportunity/edit.py
@@ -10,7 +10,6 @@ class OpportunityView(generics.UpdateAPIView):
     """
     serializer_class = OpportunitySerializer
     lookup_field = 'id'
-    permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
         return Opportunity.objects.filter(id=self.kwargs['id'])


### PR DESCRIPTION
**Issue:**
Currently, user cannot delete an opportunity when the name of the opportunity is empty.

**Fix:**
Removed text input requesting for the name of the opportunity to allow soft deletion of the opportunity.
Removed authorization check in backend. Users will not have their IDIR registered to Keycloak to handle permissions, the application is public. 

**Reference:** https://connectivitydivision.atlassian.net/browse/CIT-573