### PR TITLE
CIT-591: Regional Districts drop down (remove numbers)

### DIFF
--- a/cit3.0-web/src/components/Page/OpportunityApproveListPage/ApprovalFlyoutContent.js
+++ b/cit3.0-web/src/components/Page/OpportunityApproveListPage/ApprovalFlyoutContent.js
@@ -251,7 +251,7 @@ const ApprovalFlyoutContent = ({ title, onQuery, resetFilters, search }) => {
             {regionalDistricts &&
               regionalDistricts.map((district) => (
                 <option key={district.id} value={district.id}>
-                  {district.name}({district.area_id})
+                  {district.name}
                 </option>
               ))}
           </Form.Control>

--- a/cit3.0-web/src/components/SearchFlyoutContent/SearchFlyoutContent.js
+++ b/cit3.0-web/src/components/SearchFlyoutContent/SearchFlyoutContent.js
@@ -742,7 +742,7 @@ export default function SearchFlyoutContent({ onQuery, resetFilters, search }) {
           {regionalDistricts &&
             regionalDistricts.map((district) => (
               <option key={district.id} value={district.id}>
-                {district.name}({district.area_id})
+                {district.name}
               </option>
             ))}
         </Form.Control>


### PR DESCRIPTION
**Issue**:
Dropdown showing area_id from `pipeline_regionaldistrict` table

**Fix**:
Remove the area_id field from dropdown

**Reference**: https://connectivitydivision.atlassian.net/browse/CIT-591