### PR TITLE
Change in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
-* text eol=lf
+*.pdf binary
+*.txt eol=lf
+*.sh eol=lf
 *.png binary
 *.jpg binary


### PR DESCRIPTION
**Issue:**
warning: in the working copy of 'docs/CIT - deployment pipeline manual.pdf', CRLF will be replaced by LF the next time Git touches it

**Fix:**
- PDF handled as `binary`. 
- Explicitly txt and sh extensions have end of line `lf`

Thanks @bashbang 