### PR TITLE
CIT-608: CIOT Error when user does not enter a civic address does not prevent them from proceeding with entry process

### DIFF
--- a/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
+++ b/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
@@ -81,9 +81,10 @@ export default function AddOpportunity() {
   const [proxModalShow, setProxModalShow] = useState(false);
 
   const isInvalidAddress =
-    (!address || !localityName) &&
-    coords[0] === COORDINATE.X &&
-    coords[1] === COORDINATE.Y;
+    !PID ||
+    ((!address || !localityName) &&
+      coords[0] === COORDINATE.X &&
+      coords[1] === COORDINATE.Y);
 
   const showProximityModal = () => {
     setChangePage(true);
@@ -102,7 +103,7 @@ export default function AddOpportunity() {
   };
 
   const handleErrorModalContinue = () => {
-    if (!error.length && (!!address || !!geometry)) {
+    if (!error.length && (!isInvalidAddress || !!geometry)) {
       setWarning([]);
       setError([]);
       setChangePage(true);
@@ -131,7 +132,7 @@ export default function AddOpportunity() {
       handleProximityModalClose();
       closeModalAndContinue();
     }
-  }, [proximityInProgress, error]);
+  }, [proximityInProgress, error, warning]);
 
   useEffect(() => {
     if (municipality) {
@@ -145,7 +146,7 @@ export default function AddOpportunity() {
     setError([]);
     let errors = [];
     let warnings = [];
-    if (!address || !geometry) {
+    if (isInvalidAddress || !geometry) {
       warnings = [
         ...warnings,
         `${isInvalidAddress ? "Please enter a valid address" : ""}${
@@ -161,7 +162,7 @@ export default function AddOpportunity() {
     }
     setWarning(warnings);
     setError(errors);
-    setChangePage(agreed && !errors.length);
+    setChangePage(agreed && !errors.length && !isInvalidAddress);
     if (!proximityInProgress) {
       closeModalAndContinue();
     }


### PR DESCRIPTION
**Issue:**
User provides an invalid address which is not considered a civic address (such as name of a city) and he/she is able to proceed with step 2 to create the opportunity.

**Fix:**
User provides an invalid address and he/she is not able to go to next page.

**Test:**
- Go to Dashboard: communityinformationtool.gov.bc.ca/investmentopportunities/dashboard
- Click on Add your opportunity
- Type an address: Vancouver and select Vancouver,BC from the dropdown. Agree with the terms and click on Continue
- A warning occurs:
![image](https://user-images.githubusercontent.com/10526131/225458373-88244336-3007-4092-8587-99b60444f403.png)
- The user cannot proceed to next step until providing a valid address.
