### PR TITLE
CIT-577: Unable to create an opportunity due to Opportunity() got an unexpected keyword argument 'nearest_first_nations_object'

### DIFF
--- a/cit-api/pipeline/serializers/opportunity/edit.py
+++ b/cit-api/pipeline/serializers/opportunity/edit.py
@@ -262,6 +262,8 @@ class OpportunitySerializer(serializers.ModelSerializer):
                     **nation)
                 filtered_first_nations_distances.append(
                     filtered_first_nations_distance.pk)
+        else:
+            del validated_data['nearest_first_nations_object']
 
         filtered_municipality_distances = []
         if validated_data.get('nearest_municipalities_object'):
@@ -273,6 +275,8 @@ class OpportunitySerializer(serializers.ModelSerializer):
                     **muni)
                 filtered_municipality_distances.append(
                     municipalities_distance.pk)
+        else:
+            del validated_data['nearest_municipalities_object']
 
         # insert opportuntity with literal fields
         instance = Opportunity.objects.create(**validated_data)


### PR DESCRIPTION
**Issue:**
Creating an opportunity is failing when having empty first_nations and municipalities objects. They hold a Many to Many relationship and when they are null objects, the create function in the model is throwing unexpected keyword argument.

**Fix:**
Remove from the dictionary the entries for those objects because we do not have anything to save.

**Test:**
Currently, this fix cannot be tested easily in cit-api. You should get an opportunity with empty first nations and municipalities. However, you can try to execute a creation of opportunity via Postman with a POST request including a payload like this:
```
{
    "address": "80th St, Hudson's Hope, BC",
    "approval_status": "NEW",
    "business_contact_name": "Reyes Lopez, Arturo CITZ:EX",
    "business_contact_email": "arturo.reyeslopez@gov.bc.ca",
    "public_note": "",
    "private_note": "",
    "last_admin": "",
    "user": 48,
    "date_updated": "",
    "date_published": null,
    "nearest_airport": {
        "airport_id": 5370,
        "airport_distance": 5.94
    },
    "nearest_post_secondary": {
        "location_id": 8592,
        "location_distance": 43.53
    },
    "nearest_highway": {
        "highway_id": 705,
        "highway_distance": 2.57
    },
    "nearest_railway": {
        "railway_id": 6851,
        "railway_distance": 32.28
    },
    "nearest_municipalities_object": [],
    "nearest_lake": {
        "lake_id": 1330,
        "lake_distance": 10.56
    },
    "nearest_river": {
        "river_id": 12174,
        "river_distance": 1.33
    },
    "network_at_road": "No",
    "network_avg": "25/5",
    "nearest_fire_station": {
        "first_responder_id": 179,
        "first_responder_distance": 3.85
    },
    "nearest_police_station": {
        "first_responder_id": 913,
        "first_responder_distance": 3.74
    },
    "nearest_ambulance_station": {
        "first_responder_id": 377,
        "first_responder_distance": 3.86
    },
    "nearest_health_center": {
        "hospital_id": 3001,
        "hospital_distance": 42.97
    },
    "water_supply": "",
    "natural_gas": "",
    "sewer": "",
    "electrical": "",
    "transmission": 4.77947983402,
    "near_health": 42.96767281619,
    "near_fire": 3.84774855794,
    "near_ambulance": 3.86216785966,
    "near_police": 3.73716433652,
    "near_coast_guard": 0,
    "near_secondary_school": 43.533932665120005,
    "near_research_centre": 0,
    "near_highway": 2.57079043306,
    "near_airport": 5.941582616280001,
    "near_railway": 32.27504862887,
    "near_port": 0,
    "near_customs_port": 0,
    "near_elevation": 500,
    "near_ground": "",
    "near_lake": 10.55635068383,
    "near_river": 1.33111804224,
    "parcel_ownership": "",
    "parcel_size": null,
    "pid": "",
    "site_id": null,
    "sale_or_lease": "",
    "current_zone": "",
    "future_zone": "",
    "preferred_development": [],
    "opportunity_description": "first nations check",
    "environmental_information": "",
    "community_link": "",
    "opportunity_link": "",
    "user_id": 48,
    "municipality_id": "47",
    "regional_district_id": 5,
    "opportunity_address": "80th St, Hudson's Hope, BC",
    "geo_position": "SRID=4326;POINT(-121.8887407 56.0576702)",
    "parcel_geometry": null,
    "opportunity_name": "",
    "land_use_zoning": "",
    "ocp_zoning_code": "",
    "opportunity_property_status": "",
    "opportunity_rental_price": null,
    "opportunity_sale_price": null,
    "opportunity_road_connected": "U",
    "opportunity_water_connected": "U",
    "opportunity_water_capacity": null,
    "opportunity_sewer_connected": "U",
    "opportunity_sewer_capacity": null,
    "opportunity_natural_gas_connected": "U",
    "opportunity_natural_gas_capacity": null,
    "opportunity_electrical_connected": "U",
    "opportunity_electrical_capacity": null,
    "nearest_community": {
        "community_id": 862,
        "community_distance": 3.08
    },
    "nearest_first_nations_object": [],
    "elevation_at_location": 500,
    "soil_name": "BRANHAM",
    "soil_texture": "SIL",
    "soil_drainage": "W",
    "nearest_transmission_line": 4.78,
    "opportunity_preferred_development_v2": ""
}
```
