### PR TITLE
hotfix: CIOT- Fix invalid address being able to go to step 2

### DIFF
--- a/cit3.0-web/src/components/MapContainer/MapContainer.js
+++ b/cit3.0-web/src/components/MapContainer/MapContainer.js
@@ -14,6 +14,7 @@ import {
 export default function MapContainer({
   nearbyResources,
   coords,
+  pid,
   setCoords,
   setAddress,
   setNoAddressFlag,
@@ -49,14 +50,14 @@ export default function MapContainer({
       source.cancel("newer search");
     }
     source = CancelToken.source();
-    if (coords[0] !== 54.1722 && coords[0] !== lastCoords[0]) {
+    if (coords[0] !== 54.1722 && coords[0] !== lastCoords[0] && pid) {
       setLastCoords(coords);
       run(source);
     }
     return () => {
       source.cancel("cancel in clean up");
     };
-  }, [coords]);
+  }, [pid, coords]);
 
   return (
     <div style={{ minHeight: "100%" }} className="d-flex w-100">
@@ -86,6 +87,7 @@ MapContainer.propTypes = {
     data: PropTypes.arrayOf(PropTypes.shape),
   }).isRequired,
   coords: PropTypes.arrayOf(PropTypes.number).isRequired,
+  pid: PropTypes.arrayOf(PropTypes.string).isRequired,
   setCoords: PropTypes.func.isRequired,
   setAddress: PropTypes.func.isRequired,
   setNoAddressFlag: PropTypes.func.isRequired,

--- a/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
+++ b/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
@@ -468,6 +468,7 @@ export default function AddOpportunity() {
             <MapContainer
               nearbyResources={{}}
               coords={coords}
+              pid={PID}
               setResourceIds={(r) => dispatch(setResourceIds(r))}
               setAddress={(a) => dispatch(setAddress(a))}
               setCoords={(c) => dispatch(setCoords(c))}


### PR DESCRIPTION
**Issue:**
When user is providing an invalid address such as "Yates St, Victoria, BC", FrontEnd is sending a request to Geocoder to obtain the latitude and longitude for that address even though is invalid. In the FrontEnd, the MapContainer is using lat. and lng. to request to backend the nearest services with respect to that position.

**Fix:**
When user is providing an invalid address, never go to the next step. We are passing the PID from the main component to MapContainer to stop the request to backend and avoid proceeding to next step when the request is fulfilled.

**Test:**
- Open developer tools
- Access CIOT and create an opportunity. Enter "Yates St. Victoria, BC":
![image](https://user-images.githubusercontent.com/10526131/229191760-21c51b02-a0db-4788-ab06-8d07d19374c6.png)
- Agree terms and click on Continue. You should get a message:
![image](https://user-images.githubusercontent.com/10526131/229192573-f9b91ef9-fde3-4148-8b01-51080868cfd8.png)
- Under Network tab, ensure you do not have GET request to obtain proximity distance:
api/opportunity/proximity/?lat=[number]&lng=-[number]
