### PR TITLE
CIT-721: Users had not been inserted in pipeline_usertracking since last year

### DIFF
--- a/cit-api/pipeline/views/users/tracking.py
+++ b/cit-api/pipeline/views/users/tracking.py
@@ -10,4 +10,3 @@ class UserTrackingView(generics.CreateAPIView):
     """
     model = UserTracking
     serializer_class = UserTrackingSerializer
-    permission_classes = [IsAdminAuthenticated]

--- a/cit3.0-web/src/components/Page/PowerBi/PowerBi.js
+++ b/cit3.0-web/src/components/Page/PowerBi/PowerBi.js
@@ -258,7 +258,11 @@ export default function PowerBi() {
                         (report) => report.displayName === "Criteria Search"
                       );
                       if (community || regionalDistrict || setPage) {
-                        if (commReport[0].name !== currentPage) {
+                        if (
+                          commReport &&
+                          commReport.length &&
+                          commReport[0].name !== currentPage
+                        ) {
                           window.report
                             .setPage(commReport[0].name)
                             .catch((err) => console.log("setpage error:", err));
@@ -268,7 +272,11 @@ export default function PowerBi() {
                               .catch((err) => console.log("error: ", err));
                           }
                         }
-                      } else if (criteria[0].name !== currentPage) {
+                      } else if (
+                        criteria &&
+                        criteria.length &&
+                        criteria[0].name !== currentPage
+                      ) {
                         window.report
                           .setPage(criteria[0].name)
                           .catch((err) => console.log("setpage error:", err));


### PR DESCRIPTION
Issue:
Since 2022-07-18 pipeline_usertracking table has been inserting users accessing internal reports. We have the following URLs for internal reports: 
https://test.communityinformationtool.gov.bc.ca/cit-dashboard/internal
https://test.communityinformationtool.gov.bc.ca/cit-dashboard/internal/search-communities
Every time a user logins and access these reports must be tracked.

Fix:
Record is inserted in pipeline_usertracking table every time the internal reports are accessed. 

Related Link: https://connectivitydivision.atlassian.net/browse/CIT-721