### PR TITLE
hotfix: Eliminate redundant call to store

### DIFF
--- a/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
+++ b/cit3.0-web/src/components/Page/AddOpportunity/AddOpportunity.js
@@ -211,8 +211,8 @@ export default function AddOpportunity() {
     /// //////////////////////////
     const pid = await getPID(id);
     let countedSQM = 0;
-    dispatch(setPID(pid));
     if (pid) {
+      dispatch(setPID(pid));
       pid.forEach(async (_pid) => {
         const parcelData = await getParcelData(_pid);
         if (parcelData) {


### PR DESCRIPTION
**Issue:**
When providing an address, Front End is sending a GET request api/opportunity/proximity/ which is cancelled immediately. The opportunity is not able to load important information.

**Fix:**
Recent changes included identifying a valid address through the validation of existence of PID. Then, AddOpportunity.js is passing this value to MapContainer component as a prop. In MapContainer, we retrieve this prop through using useEffect to get any change in the value of PID and coords. 
We have to remember that every time a prop is changed in store via using dispatch, the useEffect is triggered again, so useEffect is triggered twice for PID. The first time is assigned a value null and then a real value. Considering the previous situation when we have this code:
```
if (coords[0] !== 54.1722 && coords[0] !== lastCoords[0] && pid) {
      setLastCoords(coords);
      run(source);
    }
    return () => {
      source.cancel("cancel in clean up");
    };
```

The first time is executed is when coords assigned a value, at that instant in time pid is initialized with null, so nothing happens. Second time this chunk was executed when pid is assigned again with null (this part is redundant), so again the if condition should not be accepted, but somehow is accepted in Test and changing the value of lastCoords and ran the proximity call. Then, a third time this chunk is executed when pid receives a correct value. However, this time lastCoords is equal to coords. Then, the execution is cancelled.

I eliminated the unnecessary call when PID is null to alleviate the issue.