### PR TITLE
CIT-718: [Rollback] - Rename CIT tab from Connectivity to Internet Connectivity

### DIFF
--- a/cit3.0-web/src/components/ReportOverview/ReportOverview.css
+++ b/cit3.0-web/src/components/ReportOverview/ReportOverview.css
@@ -15,7 +15,7 @@
 }
 
 .report-buttons button {
-	  width: 220px;
+    width: 180px;
     height: 44px;
     font-weight: bold !important;
     font-size: 16px;

--- a/cit3.0-web/src/components/ReportOverview/ReportOverview.js
+++ b/cit3.0-web/src/components/ReportOverview/ReportOverview.js
@@ -43,8 +43,8 @@ export default function ReportOverview({ reportFilter, user, handleLogin }) {
 
   const reportTabs = [
     {
-      pageName: "Internet Connectivity",
-      label: "Internet Connectivity",
+      pageName: "Connectivity",
+      label: "Connectivity",
       isLoginRequired: null,
       isDefault: true,
     },


### PR DESCRIPTION
PO requested to rollback the change to original label:
![image](https://user-images.githubusercontent.com/10526131/230149096-b17a8570-8d07-4d7d-a6e0-c62d753fe784.png)


Reference: https://connectivitydivision.atlassian.net/browse/CIT-718