### PR TITLE
CIT-728: CIOT: Showing 10 of x properties

### DIFF
--- a/cit3.0-web/src/components/Headers/Header/Header.js
+++ b/cit3.0-web/src/components/Headers/Header/Header.js
@@ -18,6 +18,9 @@ const Header = () => {
     if (location.pathname.includes("/investmentopportunities")) {
       return "Community Investment Opportunities Tool";
     }
+    if (location.pathname.includes("/manage/users/")) {
+      return "Community Investment Opportunities Tool";
+    }
     if (location.pathname.includes("/cit-dashboard")) {
       return "Community Information Tool";
     }
@@ -28,7 +31,10 @@ const Header = () => {
   };
 
   useEffect(() => {
-    if (location.pathname.includes("/investmentopportunities")) {
+    if (
+      location.pathname.includes("/investmentopportunities") ||
+      location.pathname.includes("/manage/users/")
+    ) {
       setIsPowerBI(false);
     } else {
       setIsPowerBI(true);

--- a/cit3.0-web/src/components/Page/EDODashboard/EDODashboard.js
+++ b/cit3.0-web/src/components/Page/EDODashboard/EDODashboard.js
@@ -54,6 +54,8 @@ export default function EDODashboard() {
             console.error(err);
             setTableData([]);
           });
+      } else {
+        setIsOpportunityLoaded(true);
       }
     });
   };

--- a/cit3.0-web/src/components/Page/OpportunityApproveListPage/OpportunityApproveListPage.js
+++ b/cit3.0-web/src/components/Page/OpportunityApproveListPage/OpportunityApproveListPage.js
@@ -140,7 +140,7 @@ const OpportunityApproveListPage = () => {
                 />
                 <p>
                   Showing {opportunities ? opportunities.length : 0} of{" "}
-                  properties
+                  {totalCount} properties
                 </p>
               </Row>
             </>


### PR DESCRIPTION
**Issue:**
- Under `Manage Opportunities`, total number of opportunities is missing in the paginator:
![image](https://user-images.githubusercontent.com/10526131/230236975-c1abc38d-b61e-4542-875c-c3652886657b.png)

- When user is soft deleted, the spinner goes forever:
![image](https://user-images.githubusercontent.com/10526131/230236865-6f5fcc11-bd45-4d5d-81ad-6be00f1b44a2.png)

- When selecting Manage Users option in the menu, the header is gone:
![image](https://user-images.githubusercontent.com/10526131/230242623-54245622-f52e-451a-a72a-546d3d66b7f9.png)

**Fix:**

- Total number of opportunities shown:
![image](https://user-images.githubusercontent.com/10526131/230237163-5129695c-0457-4a70-b363-413cea76b1c7.png)

- Spinner does not persist and appropriate message appears:
![image](https://user-images.githubusercontent.com/10526131/230237294-def3da97-b62a-4a0e-b0b9-670c70ab6df9.png)

- Header is present when selecting Manage Users:
![image](https://user-images.githubusercontent.com/10526131/230242715-72c576e5-be3a-4506-8419-b94ba25eaef6.png)
