### PR TITLE
CIT-702: Add descriptive text to new opportunIty email

### DIFF
--- a/cit-api/pipeline/views/email.py
+++ b/cit-api/pipeline/views/email.py
@@ -52,7 +52,7 @@ class EmailView(APIView):
             email_config = {
                 "bcc": [],
                 "bodyType": "html",
-                "body": "<p>A new opportunity has been submitted to the Investment Opportunities Tool for "+ str(municipality) + ", "+ str(district) +". Please review the listing to determine whether any revisions are required prior to publication.</p><p>Click here to view the listing: " + build_full_link(link) + "</p>",
+                "body": "<p>A new opportunity has been submitted to the Community Investment Opportunities Tool for "+ str(municipality) + ", "+ str(district) +". <p>Please review the opportunity to determine whether any revisions are required: " + build_full_link(link) + "</p><p>If the opportunity meets all eligibility requirements, you may approve and publish the opportunity.</p>",
                 "cc": [],
                 "delayTS": 0,
                 "encoding": "utf-8",


### PR DESCRIPTION
- Change in email text:
![image](https://user-images.githubusercontent.com/10526131/232847466-2a9db685-741b-4f74-88b3-732015e316ca.png)

- Related ticket: https://connectivitydivision.atlassian.net/browse/CIT-702