### PR TITLE
CIT-745: CIOT: Open property details in new tab

### DIFF
--- a/cit3.0-web/src/components/OpportunityListItem/OpportunityListItem.js
+++ b/cit3.0-web/src/components/OpportunityListItem/OpportunityListItem.js
@@ -114,10 +114,7 @@ const OpportunityListItem = ({
 
   return (
     <div key={opportunity.id} className="opportunity-table-row w-100">
-      <Row
-        className={publicView ? "nested-link" : ""}
-        onClick={() => !!publicView && history.push(opportunity.link)}
-      >
+      <Row className={publicView ? "nested-link" : ""}>
         <Col md={3} lg={3}>
           <div className="border-list-item opportunity-table-map-container">
             <Map
@@ -201,7 +198,9 @@ const OpportunityListItem = ({
                   <Button
                     className="p-0"
                     variant="link"
-                    onClick={() => setCurrentUrl(opportunity.link)}
+                    onClick={() => {
+                      window.open(opportunity.link, "_blank");
+                    }}
                   >
                     View property details
                   </Button>


### PR DESCRIPTION
Open in a new tab property details when clicking on button:
![image](https://user-images.githubusercontent.com/10526131/233499283-61c4d378-e316-4129-a920-9f21cd9d7660.png)


Related ticket: https://connectivitydivision.atlassian.net/browse/CIT-745