### PR TITLE
CIT-715: Rename tab on CIT web page to Facilities

### DIFF
--- a/cit3.0-web/src/components/ReportOverview/ReportOverview.js
+++ b/cit3.0-web/src/components/ReportOverview/ReportOverview.js
@@ -49,7 +49,7 @@ export default function ReportOverview({ reportFilter, user, handleLogin }) {
       isDefault: true,
     },
     {
-      pageName: "Facilities",
+      pageName: "Assets & Infrastructure",
       label: "Facilities",
       isLoginRequired: null,
       isDefault: null,


### PR DESCRIPTION
**Issue**
When clicking on Facilities is not working

**Fix**
Facilities tab is showing the appropriate report:
![image](https://user-images.githubusercontent.com/10526131/234099919-d691f9e9-da72-4fcb-88e8-ba1a0a26b087.png)


Link related: https://connectivitydivision.atlassian.net/browse/CIT-715