### PR TITLE
CIT-732: CIOT: Include spinner on all pages that load data from the opportunities table

### DIFF
--- a/cit3.0-web/src/components/Page/OpportunityApprovePage/OpportunityApprovePage.js
+++ b/cit3.0-web/src/components/Page/OpportunityApprovePage/OpportunityApprovePage.js
@@ -10,6 +10,7 @@ import {
   setOpportunity,
   getOpportunity,
   updateOpportunity,
+  resetOpportunity,
   setLastAdmin,
 } from "../../../store/actions/opportunity";
 import { getOptions, setOptions } from "../../../store/actions/options";
@@ -42,6 +43,7 @@ const OpportunityApprovePage = ({ id }) => {
   const keycloak = useKeycloakWrapper();
 
   useEffect(() => {
+    dispatch(resetOpportunity());
     let opId = id;
     if (!id) {
       const found = location.pathname.match(/(\d+)+\/?$/);


### PR DESCRIPTION
When searching an opportunity for second time using URL https://test.communityinformationtool.gov.bc.ca/manage/investmentopportunities/view/, the spinner is not shown because the opportunity.id has the value of previous opportunity. Then, when mounting the component, we are resetting the opportunity to assign null. With this change, when checking if opportunity.id is null then the spinner is shown.


Link related: https://connectivitydivision.atlassian.net/browse/CIT-732
