### PR TITLE
CIT-462   CIOT: Filter panel function - Remove Close Filter panel

### DIFF
--- a/cit3.0-web/src/components/Flyout/Flyout.js
+++ b/cit3.0-web/src/components/Flyout/Flyout.js
@@ -18,13 +18,6 @@ export default function Flyout(props) {
     <div id="search-page-layout">
       <div id="left" className={leftOpen}>
         <div className={`sidebar ${leftOpen}`}>
-          <div className="header" align="right">
-            <Button
-              onClick={toggleSidebar}
-              label="<< Close filter panel"
-              styling="btn bcgov-normal-blue close-panel-button btn"
-            />
-          </div>
           <div className="content">
             <FlyoutComponent {...flyoutProps} />
           </div>

--- a/cit3.0-web/src/components/Flyout/Flyout.scss
+++ b/cit3.0-web/src/components/Flyout/Flyout.scss
@@ -11,6 +11,7 @@
       overflow: auto;
       overflow-x: hidden;
       margin: 0.75rem;
+      padding-top: 20px;
     }
   }
   


### PR DESCRIPTION
Remove close filter panel. The panel is open always.


Ticket related: https://connectivitydivision.atlassian.net/browse/CIT-462