### PR TITLE
CIT-766: CIOT: Parcel Icon for Search Results page is not centred

### DIFF
--- a/cit3.0-web/src/components/OpportunityListItem/OpportunityListItem.js
+++ b/cit3.0-web/src/components/OpportunityListItem/OpportunityListItem.js
@@ -103,6 +103,9 @@ const OpportunityListItem = ({
     );
   };
 
+  const truncate = (str) =>
+    str.length > 252 ? `${str.substring(0, 252)} ...` : str;
+
   const saleOrLease = () => {
     const propertyStatus = options.propertyStatuses.find(
       (s) => s.code === opportunity.userInfo.saleOrLease.value
@@ -175,14 +178,7 @@ const OpportunityListItem = ({
                     paddingBottom: "0.5rem",
                   }}
                 >
-                  <LinesEllipsis
-                    className="note"
-                    text={opportunity.userInfo.opportunityDescription.value}
-                    maxLine="4"
-                    ellipsis="..."
-                    trimRight
-                    basedOn="letters"
-                  />
+                  {truncate(opportunity.userInfo.opportunityDescription.value)}
                 </Col>
                 <Col
                   style={{


### PR DESCRIPTION
**Issue**
Map is not showing the marker centered:
![image](https://github.com/bcgov/CIT/assets/10526131/3f4fe8c0-3fc9-48db-a603-d7452d38f535)

**Fix**
Replaced the use of LinesEllipsis for a function truncating the string:
![image](https://github.com/bcgov/CIT/assets/10526131/849a1084-93f9-4750-a8f5-fe6c0d2eab3b)

Related ticket: https://connectivitydivision.atlassian.net/browse/CIT-766