### PR TITLE
CIT-767: CIOT: Exclude Unknown from Search Filters

### DIFF
--- a/cit-api/pipeline/views/opportunity/list.py
+++ b/cit-api/pipeline/views/opportunity/list.py
@@ -1,14 +1,14 @@
-from rest_framework import generics
-from rest_framework import pagination
-from django.db.models import Q
 from django.contrib.gis.measure import D
-
-from pipeline.models.opportunity import Opportunity
-from pipeline.models.location_assets import Location
-from pipeline.models.general import RegionalDistrict
+from django.db.models import Q
+from pipeline.models.cen_prof_detailed_csd_attrs_sp import (
+    CEN_PROF_DETAILED_CSD_ATTRS_SP,
+)
 from pipeline.models.community import Community
+from pipeline.models.general import RegionalDistrict
+from pipeline.models.location_assets import Location
+from pipeline.models.opportunity import Opportunity
 from pipeline.serializers.opportunity.get import OpportunityGetSerializer
-from pipeline.models.cen_prof_detailed_csd_attrs_sp import CEN_PROF_DETAILED_CSD_ATTRS_SP
+from rest_framework import generics, pagination
 
 MIN_TABLE_ID = 1
 MIN_DISTANCE = 0
@@ -220,69 +220,44 @@ class OpportunitiesList(generics.ListAPIView):
         service_connected = self.request.query_params.get(service_name, None)
 
         if (service_name == 'opportunity_road_connected'):
-            if (service_connected is not None
-                    and (exclude_unknowns is None or exclude_unknowns == 'N')
-                    and service_connected == 'Y'):
+            if (service_connected is not None and service_connected == 'Y'):
+                queryset = queryset.filter(
+                    Q(opportunity_road_connected=service_connected))
+            elif (service_connected is not None and service_connected == 'N'):
                 queryset = queryset.filter(
                     Q(opportunity_road_connected=service_connected)
                     | Q(opportunity_road_connected='U'))
-            elif (service_connected is not None and exclude_unknowns == 'Y'
-                  and service_connected == 'Y'):
-                queryset = queryset.filter(opportunity_road_connected=service_connected)
-            elif (service_connected is not None and exclude_unknowns == 'Y'
-                  and service_connected == 'N'):
-                queryset = queryset.filter(~Q(opportunity_road_connected='U'))
         elif (service_name == 'opportunity_water_connected'):
-            if (service_connected is not None
-                    and (exclude_unknowns is None or exclude_unknowns == 'N')
-                    and service_connected == 'Y'):
+            if (service_connected is not None and service_connected == 'Y'):
+                queryset = queryset.filter(
+                    Q(opportunity_water_connected=service_connected))
+            elif (service_connected is not None and service_connected == 'N'):
                 queryset = queryset.filter(
                     Q(opportunity_water_connected=service_connected)
                     | Q(opportunity_water_connected='U'))
-            elif (service_connected is not None and exclude_unknowns == 'Y'
-                  and service_connected == 'Y'):
-                queryset = queryset.filter(opportunity_water_connected=service_connected)
-            elif (service_connected is not None and exclude_unknowns == 'Y'
-                  and service_connected == 'N'):
-                queryset = queryset.filter(~Q(opportunity_water_connected='U'))
         elif (service_name == 'opportunity_sewer_connected'):
-            if (service_connected is not None
-                    and (exclude_unknowns is None or exclude_unknowns == 'N')
-                    and service_connected == 'Y'):
+            if (service_connected is not None and service_connected == 'Y'):
+                queryset = queryset.filter(
+                    Q(opportunity_sewer_connected=service_connected))
+            elif (service_connected is not None and service_connected == 'N'):
                 queryset = queryset.filter(
                     Q(opportunity_sewer_connected=service_connected)
                     | Q(opportunity_sewer_connected='U'))
-            elif (service_connected is not None and exclude_unknowns == 'Y'
-                  and service_connected == 'Y'):
-                queryset = queryset.filter(opportunity_sewer_connected=service_connected)
-            elif (service_connected is not None and exclude_unknowns == 'Y'
-                  and service_connected == 'N'):
-                queryset = queryset.filter(~Q(opportunity_sewer_connected='U'))
         elif (service_name == 'opportunity_electrical_connected'):
-            if (service_connected is not None
-                    and (exclude_unknowns is None or exclude_unknowns == 'N')
-                    and service_connected == 'Y'):
+            if (service_connected is not None and service_connected == 'Y'):
+                queryset = queryset.filter(
+                    Q(opportunity_electrical_connected=service_connected))
+            elif (service_connected is not None and service_connected == 'N'):
                 queryset = queryset.filter(
                     Q(opportunity_electrical_connected=service_connected)
                     | Q(opportunity_electrical_connected='U'))
-            elif (service_connected is not None and exclude_unknowns == 'Y'
-                  and service_connected == 'Y'):
-                queryset = queryset.filter(opportunity_electrical_connected=service_connected)
-            elif (service_connected is not None and exclude_unknowns == 'Y'
-                  and service_connected == 'N'):
-                queryset = queryset.filter(~Q(opportunity_electrical_connected='U'))
         elif (service_name == 'opportunity_natural_gas_connected'):
-            if (service_connected is not None
-                    and (exclude_unknowns is None or exclude_unknowns == 'N')
-                    and service_connected == 'Y'):
+            if (service_connected is not None and service_connected == 'Y'):
+                queryset = queryset.filter(
+                    Q(opportunity_natural_gas_connected=service_connected))
+            elif (service_connected is not None and service_connected == 'N'):
                 queryset = queryset.filter(
                     Q(opportunity_natural_gas_connected=service_connected)
                     | Q(opportunity_natural_gas_connected='U'))
-            elif (service_connected is not None and exclude_unknowns == 'Y'
-                  and service_connected == 'Y'):
-                queryset = queryset.filter(opportunity_natural_gas_connected=service_connected)
-            elif (service_connected is not None and exclude_unknowns == 'Y'
-                  and service_connected == 'N'):
-                queryset = queryset.filter(~Q(opportunity_natural_gas_connected='U'))
 
         return queryset

--- a/cit3.0-web/src/components/SearchFlyoutContent/SearchFlyoutContent.js
+++ b/cit3.0-web/src/components/SearchFlyoutContent/SearchFlyoutContent.js
@@ -552,33 +552,6 @@ export default function SearchFlyoutContent({ onQuery, resetFilters, search }) {
         <Col xs="6">
           <h3>Site Servicing</h3>
         </Col>
-        <Col xs="auto" className="exclude-unknown-section">
-          <input
-            type="checkbox"
-            checked={excludeUnknowns}
-            value={excludeUnknowns}
-            onChange={() => {
-              onQuery({
-                [FORM_EXCLUDE_UNKNOWNS]: !excludeUnknowns ? "Y" : "N",
-              });
-              setExcludeUnknowns(!excludeUnknowns);
-            }}
-          />
-        </Col>
-        <Col xs="auto" className="exclude-unknown-section">
-          <span>
-            Exclude Unknown{" "}
-            <span>
-              <OverlayTrigger
-                placement="right"
-                delay={{ show: 100, hide: 100 }}
-                overlay={renderTooltip}
-              >
-                <MdHelp color="#2693e6" size="1.3em" />
-              </OverlayTrigger>
-            </span>
-          </span>
-        </Col>
       </Row>
       {siteServicingSection}
       <h3>Transportation</h3>


### PR DESCRIPTION
Exclude unknown check in Search Filters. When user selects "No", then unknown values are also considered for the property.

For instance, the following filter:
![image](https://github.com/bcgov/CIT/assets/10526131/41402741-a24f-490f-8e4d-920c2a641c90)

Generate the next query filters:
```
SELECT "pipeline_opportunity"."id", 
       "pipeline_opportunity"."opportunity_address",
        "pipeline_opportunity"."opportunity_road_connected",
        "pipeline_opportunity"."opportunity_water_connected",
        "pipeline_opportunity"."opportunity_sewer_connected",
        "pipeline_opportunity"."opportunity_electrical_connected",
        "pipeline_opportunity"."opportunity_natural_gas_connected" 
FROM "pipeline_opportunity" 
WHERE  "pipeline_opportunity"."deleted" = False AND 
       "pipeline_opportunity"."approval_status_id" IN ('PUBL') AND 
       "pipeline_opportunity"."opportunity_road_connected" = 'Y' AND 
       "pipeline_opportunity"."opportunity_water_connected" = 'Y' AND 
       ("pipeline_opportunity"."opportunity_sewer_connected" = 'N' OR "pipeline_opportunity"."opportunity_sewer_connected" = 'U') AND 
       ("pipeline_opportunity"."opportunity_electrical_connected" = 'N' OR "pipeline_opportunity"."opportunity_electrical_connected" = 'U') AND 
       ("pipeline_opportunity"."opportunity_natural_gas_connected" = 'N' OR "pipeline_opportunity"."opportunity_natural_gas_connected" = 'U') 
ORDER BY "pipeline_opportunity"."id" ASC
```

Ticket related: https://connectivitydivision.atlassian.net/browse/CIT-767