### PR TITLE
CIT-732:CIOT: Include spinner on all pages that load data from the opportunities table

### DIFF
--- a/cit3.0-web/src/components/Page/OpportunityPage/OpportunityPage.js
+++ b/cit3.0-web/src/components/Page/OpportunityPage/OpportunityPage.js
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useLocation, useHistory, Link } from "react-router-dom";
 import { Button } from "shared-components";
 import { Alert } from "shared-components/build/components/alert/Alert";
-import { Col, Container, Row } from "react-bootstrap";
+import { Col, Container, Row, Spinner } from "react-bootstrap";
 import OpportunityView from "../../OpportunityView/OpportunityView";
 import {
   setOpportunity,
@@ -22,6 +22,7 @@ const OpportunityPage = ({ id }) => {
   const [buttonText, setButtonText] = useState("Go Back");
 
   useEffect(() => {
+    dispatch(resetOpportunity());
     let opId = id;
     if (!id) {
       const found = location.pathname.match(/(\d+)+\/?$/);
@@ -74,100 +75,110 @@ const OpportunityPage = ({ id }) => {
 
   return (
     <div data-testid="OpportunityPage">
-      <Container className="p-0 mt-3">
-        <Row className="no-print">
-          <Col className="align-self-end">
-            {history.action !== "POP" && (
-              <Button
-                label={buttonText}
-                styling="bcgov-normal-blue btn px-4"
-                onClick={resetState}
-                onKeyDown={resetState}
-              />
-            )}
-            <textarea
-              readOnly
-              id="link"
-              className="visually-hidden"
-              value={window.location}
-            />
-          </Col>
-          <Col>
-            <div className="d-flex flex-grow-1 justify-content-end">
-              <div className="d-flex flex-column">
-                <button
-                  type="button"
-                  className="a-tag"
-                  onClick={() => copyLink()}
-                >
-                  Copy Listing Link
-                </button>
-                <button
-                  type="button"
-                  className="a-tag"
-                  onClick={() => emailLink()}
-                >
-                  Email Listing Link
-                </button>
-                <button
-                  type="button"
-                  className="a-tag"
-                  onClick={() => openPdf()}
-                >
-                  View Listing PDF
-                </button>
-              </div>
-            </div>
-          </Col>
-        </Row>
-        <hr className="my-3 hr-bold no-print" />
-      </Container>
-      <OpportunityView view="all" />
+      {opportunity.id ? (
+        <>
+          <Container className="p-0 mt-3">
+            <Row className="no-print">
+              <Col className="align-self-end">
+                {history.action !== "POP" && (
+                  <Button
+                    label={buttonText}
+                    styling="bcgov-normal-blue btn px-4"
+                    onClick={resetState}
+                    onKeyDown={resetState}
+                  />
+                )}
+                <textarea
+                  readOnly
+                  id="link"
+                  className="visually-hidden"
+                  value={window.location}
+                />
+              </Col>
+              <Col>
+                <div className="d-flex flex-grow-1 justify-content-end">
+                  <div className="d-flex flex-column">
+                    <button
+                      type="button"
+                      className="a-tag"
+                      onClick={() => copyLink()}
+                    >
+                      Copy Listing Link
+                    </button>
+                    <button
+                      type="button"
+                      className="a-tag"
+                      onClick={() => emailLink()}
+                    >
+                      Email Listing Link
+                    </button>
+                    <button
+                      type="button"
+                      className="a-tag"
+                      onClick={() => openPdf()}
+                    >
+                      View Listing PDF
+                    </button>
+                  </div>
+                </div>
+              </Col>
+            </Row>
+            <hr className="my-3 hr-bold no-print" />
+          </Container>
+          <OpportunityView view="all" />
 
-      <Container className="p-0 no-print">
-        <Alert
-          icon={<></>}
-          type="warning"
-          styling="bcgov-warning-background mb-4"
-          element={
-            <span>
-              Property listings on this site include information provided by
-              authorized community representatives and obtained from{" "}
-              <span>
-                {" "}
-                <Link to="/investmentopportunities/datasources">
-                  open data sources.
-                </Link>
-              </span>{" "}
-              The Province of British Columbia has not verified the information
-              and prospective purchasers, lessors and others should conduct
-              their own usual due diligence and make such enquiries as they deem
-              necessary before purchasing, leasing or otherwise investing in the
-              subject site. Prospective purchasers, lessors and other interested
-              in the subject site should check existing laws and regulations to
-              confirm that this particular property is suitable for their
-              intended purpose or use and what permits, approvals and
-              consultations, including with Indigenous communities, are required
-              in order to develop such property, as well as any costs associated
-              with such development. Listings are for information purposes only
-              and are not intended to provide investment advice. Reliance upon
-              any information shall be at the user’s sole risk. All information
-              should be verified independently before being used or relied upon.
-              The Province of British Columbia does not guarantee the quality,
-              accuracy, completeness or timeliness of this information; and
-              assumes no obligation to update this information or advise on
-              further developments. The Province of British Columbia disclaims
-              any liability for unauthorized use or reproduction of any
-              information contained in this document and is not responsible for
-              any direct, indirect, special or consequential damages or any
-              other damages caused, arising out of or in connection with use of
-              this information. The Province of British Columbia is not acting
-              as a real estate broker or agent for any party in connection with
-              any of the properties described on this website.
-            </span>
-          }
-        />
-      </Container>
+          <Container className="p-0 no-print">
+            <Alert
+              icon={<></>}
+              type="warning"
+              styling="bcgov-warning-background mb-4"
+              element={
+                <span>
+                  Property listings on this site include information provided by
+                  authorized community representatives and obtained from{" "}
+                  <span>
+                    {" "}
+                    <Link to="/investmentopportunities/datasources">
+                      open data sources.
+                    </Link>
+                  </span>{" "}
+                  The Province of British Columbia has not verified the
+                  information and prospective purchasers, lessors and others
+                  should conduct their own usual due diligence and make such
+                  enquiries as they deem necessary before purchasing, leasing or
+                  otherwise investing in the subject site. Prospective
+                  purchasers, lessors and other interested in the subject site
+                  should check existing laws and regulations to confirm that
+                  this particular property is suitable for their intended
+                  purpose or use and what permits, approvals and consultations,
+                  including with Indigenous communities, are required in order
+                  to develop such property, as well as any costs associated with
+                  such development. Listings are for information purposes only
+                  and are not intended to provide investment advice. Reliance
+                  upon any information shall be at the user’s sole risk. All
+                  information should be verified independently before being used
+                  or relied upon. The Province of British Columbia does not
+                  guarantee the quality, accuracy, completeness or timeliness of
+                  this information; and assumes no obligation to update this
+                  information or advise on further developments. The Province of
+                  British Columbia disclaims any liability for unauthorized use
+                  or reproduction of any information contained in this document
+                  and is not responsible for any direct, indirect, special or
+                  consequential damages or any other damages caused, arising out
+                  of or in connection with use of this information. The Province
+                  of British Columbia is not acting as a real estate broker or
+                  agent for any party in connection with any of the properties
+                  described on this website.
+                </span>
+              }
+            />
+          </Container>
+        </>
+      ) : (
+        <div className="center-page-spinner-opportunities">
+          <Spinner animation="border" />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
On Dashboard, when clicking on `View Listing` in one of the opportunities, it is taking to OpportunityPage under the route /investmentopportunities/view/.  When mounting the page it is showing the previous opportunity, spinner should be loaded while waiting for the opportunity to be loaded.