### PR TITLE
CIT-777: Random icons on map

### DIFF
--- a/cit3.0-web/src/components/Map/Map.js
+++ b/cit3.0-web/src/components/Map/Map.js
@@ -127,17 +127,6 @@ export default function Map({
             <Popup>{address || null}</Popup>
           </Marker>
         ) : null}
-        {JSON.stringify(nearbyResources) !== "{}"
-          ? Object.entries(nearbyResources).map(([resource, resourceData]) =>
-              resource !== "community" ? (
-                <ResourceMarker
-                  key={resource}
-                  resourceName={resource}
-                  resources={resourceData}
-                />
-              ) : null
-            )
-          : null}
       </>
     );
     zoomLevel = 5; // do not change!


### PR DESCRIPTION
Remove nearby resources from the map in Step 2 (View Data).

In MapContainer NearbyResources are set after obtaining the values from backend. When user clicks on Continue, the second step is display using OpportunityView and because NearbyResources is set then in Map.js the code iterated over the resources and added a marker in the map.

This change is removing that logic and only the address in displayed in the map.

Related ticket: https://connectivitydivision.atlassian.net/browse/CIT-777