### PR TITLE
Fix issue when processing proximity

### DIFF
--- a/cit-api/pipeline/views/proximity.py
+++ b/cit-api/pipeline/views/proximity.py
@@ -264,8 +264,9 @@ class ProximityView(APIView):
                 # Valid population found, else not valid
                 #
                 # Tech Loan: The area overlap query below is to patch up misssing data in the Communities V6 spread sheet
-                municipalities['features'][index]['properties']['community_id']= community_queryset.values()[0]['id']
                 if len(community_queryset):
+                    municipalities['features'][index]['properties'][
+                        'community_id']= community_queryset.values()[0]['id']
                     municipalities['features'][index]['properties'][
                         'population'] = community_queryset.values()[0]['count']
                 else:


### PR DESCRIPTION
Ensure object `community_queryset`  is not empty