### PR TITLE
added media folder to api deployment

### DIFF
--- a/openshift/cit/templates/deployments.yaml
+++ b/openshift/cit/templates/deployments.yaml
@@ -44,8 +44,14 @@ spec:
                 name: {{ .Values.app_name }}-api-config
           imagePullPolicy: Always
           terminationMessagePolicy: File
+          volumeMounts:
+            - name: media
+              mountPath: /media
       restartPolicy: Always
       serviceAccount: default
+      volumes:
+        - name: media
+          emptyDir: {}
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
the BCA upload files needs a temp location to store its files.  Creating a folder to allow this to happen.